### PR TITLE
Fix 2FA callback in webview login

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,7 +57,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        // 19+ required by the webview_flutter plugin
+        minSdkVersion 19
         targetSdkVersion 30
         multiDexEnabled true
     }

--- a/android/fastlane/metadata/android/free/en-US/changelogs/46.txt
+++ b/android/fastlane/metadata/android/free/en-US/changelogs/46.txt
@@ -1,4 +1,4 @@
 Version 0.5.6
 
-· Fix webview login with 2 factor authentication
-· Fix keyboard in webview login doesn't allow clipboard access
+· Fixed webview login with 2 factor authentication
+· Fixed keyboard in webview login doesn't allow clipboard access

--- a/android/fastlane/metadata/android/free/en-US/changelogs/46.txt
+++ b/android/fastlane/metadata/android/free/en-US/changelogs/46.txt
@@ -1,0 +1,4 @@
+Version 0.5.6
+
+· Fix webview login with 2 factor authentication
+· Fix keyboard in webview login doesn't allow clipboard access

--- a/lib/api/twitter/auth/twitter_login_webview.dart
+++ b/lib/api/twitter/auth/twitter_login_webview.dart
@@ -10,7 +10,7 @@ typedef OnExternalNavigation = void Function(String url);
 /// called with the callback url as a [Uri] instance.
 /// The callback url contains the token and secret as query params on
 /// success, or a denied query param on user cancel.
-class TwitterLoginWebview extends StatelessWidget {
+class TwitterLoginWebview extends StatefulWidget {
   const TwitterLoginWebview({
     @required this.token,
     @required this.onExternalNavigation,
@@ -19,20 +19,39 @@ class TwitterLoginWebview extends StatelessWidget {
   final String token;
   final OnExternalNavigation onExternalNavigation;
 
+  @override
+  _TwitterLoginWebviewState createState() => _TwitterLoginWebviewState();
+}
+
+class _TwitterLoginWebviewState extends State<TwitterLoginWebview> {
+  @override
+  void initState() {
+    super.initState();
+
+    WebView.platform = SurfaceAndroidWebView();
+  }
+
   NavigationDecision _navigationDelegate(
     BuildContext context,
     NavigationRequest navigation,
   ) {
     if (navigation.url.startsWith(TwitterAuth.callbackUrl)) {
+      // received callback - pop navigator with callback url
       Navigator.of(context).pop(Uri.dataFromString(navigation.url));
       return NavigationDecision.prevent;
     } else {
-      if (navigation.url.contains('twitter.com/oauth/authorize')) {
+      if (<String>[
+        'twitter.com/oauth/authorize', // login page
+        'api.twitter.com/login/error', // login error (e.g. invalid username / password)
+        'api.twitter.com/account/login_verification' // 2 factor authentication
+      ].any(navigation.url.contains)) {
+        // stay in in-app webview
         return NavigationDecision.navigate;
       } else {
         // when navigating away from the sign in page (help page, signup
         // page, etc.)
-        onExternalNavigation(navigation.url);
+        // used to open external browser
+        widget.onExternalNavigation(navigation.url);
         return NavigationDecision.prevent;
       }
     }
@@ -45,7 +64,7 @@ class TwitterLoginWebview extends StatelessWidget {
       'oauth/authorize',
       <String, String>{
         'force_login': 'true',
-        'oauth_token': token,
+        'oauth_token': widget.token,
       },
     );
 


### PR DESCRIPTION
Adds handling for the 2-factor-authentication in the in-app webview login.
Additionally the 'Hybrid Composition based platform views implementation' of the webview is used that has better keyboard support but requires the minSdkVersion to be set to 19 from 16 (Android 4.1 -> 4.4)

Fixes #332 