### PR TITLE
Fix download not working for some people & Add saving images from cache

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,31 +19,6 @@
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true">
 
-        <provider
-            android:name="androidx.work.impl.WorkManagerInitializer"
-            android:authorities="${applicationId}.workmanager-init"
-            tools:node="remove" />
-
-        <provider
-            android:name="vn.hunghd.flutterdownloader.FlutterDownloaderInitializer"
-            android:authorities="${applicationId}.flutter-downloader-init"
-            android:exported="false">
-            
-            <meta-data
-                android:name="vn.hunghd.flutterdownloader.MAX_CONCURRENT_TASKS"
-                android:value="5" />
-        </provider>
-
-        <provider
-            android:name="vn.hunghd.flutterdownloader.DownloadedFileProvider"
-            android:authorities="${applicationId}.flutter_downloader.provider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-              <meta-data
-                  android:name="android.support.FILE_PROVIDER_PATHS"
-                  android:resource="@xml/provider_paths"/>
-        </provider>
-        
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/android/fastlane/metadata/android/free/en-US/changelogs/51.txt
+++ b/android/fastlane/metadata/android/free/en-US/changelogs/51.txt
@@ -1,0 +1,5 @@
+Version 0.6.3
+2021-05-24
+
+· Fixed downloading images & videos failed for some users
+· Changed images are saved from cache when possible

--- a/lib/api/twitter/data/tweet_data.dart
+++ b/lib/api/twitter/data/tweet_data.dart
@@ -246,4 +246,18 @@ class TweetData {
 
     return visibleText.trim();
   }
+
+  /// Returns the [MediaType] for the media of this tweet or `null` if this
+  /// tweet has no media.
+  MediaType? get mediaType {
+    if (hasImages) {
+      return MediaType.image;
+    } else if (hasGif) {
+      return MediaType.gif;
+    } else if (hasVideo) {
+      return MediaType.video;
+    } else {
+      return null;
+    }
+  }
 }

--- a/lib/api/twitter/media_type.dart
+++ b/lib/api/twitter/media_type.dart
@@ -9,3 +9,17 @@ enum MediaType {
   gif,
   video,
 }
+
+extension MediaTypeExtension on MediaType {
+  /// The human readable name of the type.
+  String get name {
+    switch (this) {
+      case MediaType.gif:
+        return 'gif';
+      case MediaType.video:
+        return 'video';
+      case MediaType.image:
+        return 'image';
+    }
+  }
+}

--- a/lib/components/common/application/bloc/application_event.dart
+++ b/lib/components/common/application/bloc/application_event.dart
@@ -45,7 +45,6 @@ class InitializeEvent extends ApplicationEvent {
       FlutterDisplayMode.setHighRefreshRate(),
       app<HarpyPreferences>().initialize(),
       app<ConnectivityService>().initialize(),
-      app<DownloadService>().initialize(),
     ]);
   }
 

--- a/lib/components/common/timeline/media_timeline/widget/media_timeline_gallery_overlay.dart
+++ b/lib/components/common/timeline/media_timeline/widget/media_timeline_gallery_overlay.dart
@@ -73,7 +73,7 @@ class _MediaTimelineGalleryOverlayState
         tweetBloc: _bloc,
         enableImmersiveMode: false,
         onOpenExternally: () => defaultOnMediaOpenExternally(_mediaUrl),
-        onDownload: () => defaultOnMediaDownload(_mediaUrl),
+        onDownload: () => defaultOnMediaDownload(_tweet.mediaType, _mediaUrl),
         onShare: () => defaultOnMediaShare(_mediaUrl),
         onShowTweet: () => app<HarpyNavigator>().pushRepliesScreen(
           tweet: _tweet,

--- a/lib/components/common/timeline/media_timeline/widget/media_timeline_media_widget.dart
+++ b/lib/components/common/timeline/media_timeline/widget/media_timeline_media_widget.dart
@@ -26,6 +26,7 @@ class MediaTimelineMediaWidget extends StatelessWidget {
     showTweetMediaBottomSheet(
       context,
       url: entry.media!.bestUrl,
+      mediaType: entry.tweet.mediaType,
     );
   }
 

--- a/lib/components/common/tweet/widgets/media/tweet_gif.dart
+++ b/lib/components/common/tweet/widgets/media/tweet_gif.dart
@@ -57,6 +57,7 @@ class TweetGif extends StatelessWidget {
         onGifLongPress: () => showTweetMediaBottomSheet(
           context,
           url: tweetBloc.downloadMediaUrl(tweet!),
+          mediaType: MediaType.gif,
         ),
         autoplay: mediaPreferences.shouldAutoplayMedia,
         allowVerticalOverflow: true,

--- a/lib/components/common/tweet/widgets/media/tweet_images.dart
+++ b/lib/components/common/tweet/widgets/media/tweet_images.dart
@@ -41,7 +41,10 @@ class _TweetImagesState extends State<TweetImages> {
       tweet: widget.tweet!,
       tweetBloc: widget.tweetBloc,
       overlap: true,
-      onDownload: () => defaultOnMediaDownload(mediaUrl),
+      onDownload: () => defaultOnMediaDownload(
+        widget.tweet!.mediaType,
+        mediaUrl,
+      ),
       onOpenExternally: () => defaultOnMediaOpenExternally(mediaUrl),
       onShare: () => defaultOnMediaShare(mediaUrl),
       child: HarpyMediaGallery.builder(
@@ -63,6 +66,7 @@ class _TweetImagesState extends State<TweetImages> {
     showTweetMediaBottomSheet(
       context,
       url: widget.tweetBloc.downloadMediaUrl(widget.tweet!, index: index),
+      mediaType: MediaType.image,
     );
   }
 

--- a/lib/components/common/tweet/widgets/media/tweet_media_bottom_sheet.dart
+++ b/lib/components/common/tweet/widgets/media/tweet_media_bottom_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:harpy/api/api.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 
@@ -11,13 +12,14 @@ import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 void showTweetMediaBottomSheet(
   BuildContext context, {
   String? url,
+  MediaType? mediaType,
   VoidCallback? onOpenExternally,
   VoidCallback? onDownload,
   VoidCallback? onShare,
 }) {
-  assert(onOpenExternally != null || url != null);
-  assert(onDownload != null || url != null);
-  assert(onShare != null || url != null);
+  assert(onOpenExternally != null || (url != null && mediaType != null));
+  assert(onDownload != null || (url != null && mediaType != null));
+  assert(onShare != null || (url != null && mediaType != null));
 
   showHarpyBottomSheet<void>(
     context,
@@ -43,7 +45,7 @@ void showTweetMediaBottomSheet(
           if (onDownload != null) {
             onDownload();
           } else {
-            defaultOnMediaDownload(url);
+            defaultOnMediaDownload(mediaType, url);
           }
 
           Navigator.of(context).maybePop();

--- a/lib/components/common/tweet/widgets/media/tweet_video.dart
+++ b/lib/components/common/tweet/widgets/media/tweet_video.dart
@@ -50,6 +50,7 @@ class TweetVideo extends StatelessWidget {
           onVideoPlayerLongPress: () => showTweetMediaBottomSheet(
             context,
             url: tweetBloc.downloadMediaUrl(tweet!),
+            mediaType: MediaType.video,
           ),
           autoplay: mediaPreferences.shouldAutoplayVideos,
           allowVerticalOverflow: true,

--- a/lib/components/common/tweet/widgets/overlay/media_overlay.dart
+++ b/lib/components/common/tweet/widgets/overlay/media_overlay.dart
@@ -39,7 +39,7 @@ Future<void> defaultOnMediaDownload(MediaType? type, String? mediaUrl) async {
             name: fileName,
             tryCache: type == MediaType.image,
             onSuccess: () => notifier.value = DownloadStatus(
-              message: 'saved ${type.name}',
+              message: '${type.name} saved',
               state: DownloadState.successful,
             ),
             onFailure: () => notifier.value = const DownloadStatus(

--- a/lib/components/common/tweet/widgets/overlay/media_overlay.dart
+++ b/lib/components/common/tweet/widgets/overlay/media_overlay.dart
@@ -14,8 +14,8 @@ void defaultOnMediaOpenExternally(String? mediaUrl) {
 }
 
 /// Default behaviour to download a tweet media.
-void defaultOnMediaDownload(String? mediaUrl) {
-  if (mediaUrl != null) {
+void defaultOnMediaDownload(MediaType? type, String? mediaUrl) {
+  if (type != null && mediaUrl != null) {
     final downloadService = app<DownloadService>();
 
     final url = mediaUrl;
@@ -23,7 +23,7 @@ void defaultOnMediaDownload(String? mediaUrl) {
 
     if (fileName != null) {
       downloadService
-          .download(url: url, name: fileName)
+          .download(url: url, name: fileName, mediaType: type)
           .catchError(silentErrorHandler);
     }
   }
@@ -95,7 +95,8 @@ class MediaOverlay extends StatefulWidget {
           enableImmersiveMode: enableImmersiveMode,
           enableDismissible: enableDismissible,
           overlap: overlap,
-          onDownload: onDownload ?? () => defaultOnMediaDownload(mediaUrl),
+          onDownload: onDownload ??
+              () => defaultOnMediaDownload(tweet.mediaType, mediaUrl),
           onOpenExternally:
               onOpenExternally ?? () => defaultOnMediaOpenExternally(mediaUrl),
           onShare: onShare ?? () => defaultOnMediaShare(mediaUrl),

--- a/lib/components/components.dart
+++ b/lib/components/components.dart
@@ -213,6 +213,7 @@ export 'widgets/misc/custom_animated_crossfade.dart';
 export 'widgets/misc/custom_dismissible.dart';
 export 'widgets/misc/custom_refresh_indicator.dart';
 export 'widgets/misc/custom_sliver_app_bar.dart';
+export 'widgets/misc/download_status_message.dart';
 export 'widgets/misc/flare_icons.dart';
 export 'widgets/misc/followers_count.dart';
 export 'widgets/misc/global_bloc_provider.dart';

--- a/lib/components/widgets/misc/download_status_message.dart
+++ b/lib/components/widgets/misc/download_status_message.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:harpy/components/components.dart';
+import 'package:harpy/core/core.dart';
+import 'package:harpy/harpy_widgets/animations/animation_constants.dart';
+
+class DownloadStatusMessage extends StatefulWidget {
+  const DownloadStatusMessage({
+    required this.notifier,
+    Key? key,
+  }) : super(key: key);
+
+  final ValueNotifier<DownloadStatus> notifier;
+
+  @override
+  _DownloadStatusMessageState createState() => _DownloadStatusMessageState();
+}
+
+class _DownloadStatusMessageState extends State<DownloadStatusMessage> {
+  @override
+  void initState() {
+    super.initState();
+
+    widget.notifier.addListener(() {
+      if (mounted) {
+        setState(() {});
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final status = widget.notifier.value;
+
+    return AnimatedSwitcher(
+      duration: kShortAnimationDuration,
+      switchInCurve: Curves.easeInOut,
+      switchOutCurve: Curves.easeInOut,
+      child: Row(
+        key: ValueKey(status),
+        children: [
+          Flexible(child: Text(status.message)),
+          if (status.state == DownloadState.inProgress) ...[
+            defaultHorizontalSpacer,
+            const SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/widgets/misc/download_status_message.dart
+++ b/lib/components/widgets/misc/download_status_message.dart
@@ -3,6 +3,7 @@ import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
 import 'package:harpy/harpy_widgets/animations/animation_constants.dart';
 
+/// Builds a status message based on the [DownloadStatus] of the [notifier].
 class DownloadStatusMessage extends StatefulWidget {
   const DownloadStatusMessage({
     required this.notifier,

--- a/lib/components/widgets/misc/harpy_message.dart
+++ b/lib/components/widgets/misc/harpy_message.dart
@@ -20,6 +20,8 @@ class HarpyMessageState extends State<HarpyMessage> {
   final GlobalKey<ScaffoldMessengerState> _messengerKey =
       GlobalKey<ScaffoldMessengerState>();
 
+  ScaffoldMessengerState get state => _messengerKey.currentState!;
+
   void show(String message, [SnackBarAction? action]) {
     _messengerKey.currentState!.showSnackBar(
       SnackBar(
@@ -27,6 +29,10 @@ class HarpyMessageState extends State<HarpyMessage> {
         action: action,
       ),
     );
+  }
+
+  void showCustom(SnackBar snackBar) {
+    _messengerKey.currentState!.showSnackBar(snackBar);
   }
 
   @override

--- a/lib/core/services/download_service.dart
+++ b/lib/core/services/download_service.dart
@@ -1,48 +1,107 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:android_path_provider/android_path_provider.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter_downloader/flutter_downloader.dart';
+import 'package:flutter/material.dart';
+import 'package:harpy/api/api.dart';
+import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
+import 'package:harpy/misc/misc.dart';
+import 'package:http/http.dart' as http;
 import 'package:permission_handler/permission_handler.dart';
 
-/// Uses the [FlutterDownloader] to download files in the background with a
-/// status notification.
-///
-/// Files are downloaded into the download directory using
-/// [AndroidPathProvider].
-///
-/// To write into the download directory, additional permissions have to be
-/// granted at runtime.
-///
-/// See https://pub.dev/packages/flutter_downloader.
-/// See https://pub.dev/packages/downloads_path_provider.
-class DownloadService {
+class DownloadService with HarpyLogger {
   MessageService get messageService => app<MessageService>();
 
-  Future<void> initialize() async {
-    await FlutterDownloader.initialize(debug: !kReleaseMode);
-    // register an empty callback to fix an issue in the flutter_download
-    // package
-    FlutterDownloader.registerCallback(_emptyCallback);
-  }
-
+  /// Downloads the file for the [url] into the downloads directory.
+  ///
+  /// If the file is an image, we try to get the data from the image cache
+  /// first before downloading the image.
   Future<void> download({
     required String url,
-    String? name,
+    required String name,
+    required MediaType mediaType,
   }) async {
     final path = await _requestDownloadDirectory();
 
+    final notifier = ValueNotifier<DownloadStatus>(
+      const DownloadStatus(
+        message: '',
+        state: DownloadState.inProgress,
+      ),
+    );
+
+    final snackBar = SnackBar(
+      content: DownloadStatusMessage(notifier: notifier),
+      duration: const Duration(seconds: 10),
+    );
+
+    messageService.showCustom(snackBar);
+
     if (path != null) {
       try {
-        await FlutterDownloader.enqueue(
-          url: url,
-          savedDir: path,
-          fileName: name,
-        );
+        // create directory in case it doesn't exist already
+        final directory = Directory(path);
+        directory.createSync(recursive: true);
 
-        messageService.show('download started');
-      } catch (e) {
-        messageService.show('download failed');
+        final file = File('${directory.path}/$name');
+
+        Uint8List? cachedImageData;
+
+        String type;
+
+        if (mediaType == MediaType.image) {
+          type = 'image';
+          notifier.value = const DownloadStatus(
+            message: 'saving image...',
+            state: DownloadState.inProgress,
+          );
+
+          cachedImageData = await imageDataFromCache(
+            NetworkImage(url, scale: 1),
+          );
+        } else if (mediaType == MediaType.gif) {
+          type = 'gif';
+        } else {
+          type = 'video';
+        }
+
+        if (cachedImageData != null) {
+          log.fine('saving image from cache');
+          file.writeAsBytesSync(cachedImageData);
+        } else {
+          log.fine('downloading media');
+
+          notifier.value = DownloadStatus(
+            message: 'downloading $type...',
+            state: DownloadState.inProgress,
+          );
+
+          final response = await http
+              .get(Uri.parse(url))
+              .timeout(const Duration(seconds: 30));
+
+          file.writeAsBytesSync(response.bodyBytes);
+        }
+
+        log.fine('successfully saved $type');
+
+        notifier.value = DownloadStatus(
+          message: 'saved $type',
+          state: DownloadState.successful,
+        );
+      } catch (e, st) {
+        log.severe('error while trying to download file', e, st);
+
+        notifier.value = const DownloadStatus(
+          message: 'download failed',
+          state: DownloadState.failed,
+        );
       }
+
+      await Future<void>.delayed(const Duration(seconds: 3));
+      messageService.messageState.state.hideCurrentSnackBar();
     }
   }
 
@@ -61,4 +120,22 @@ class DownloadService {
   }
 }
 
-void _emptyCallback(String id, DownloadTaskStatus status, int progress) {}
+/// The current status of a download.
+///
+/// Used to display a status message in a snack bar.
+@immutable
+class DownloadStatus {
+  const DownloadStatus({
+    required this.message,
+    required this.state,
+  });
+
+  final String message;
+  final DownloadState state;
+}
+
+enum DownloadState {
+  inProgress,
+  successful,
+  failed,
+}

--- a/lib/core/services/message_service.dart
+++ b/lib/core/services/message_service.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:harpy/components/components.dart';
 
 class MessageService {
-  HarpyMessageState? get messageState => HarpyMessage.globalKey.currentState;
+  HarpyMessageState get messageState => HarpyMessage.globalKey.currentState!;
 
   /// Shows a global [SnackBar] using the [HarpyMessage].
   void show(String message, [SnackBarAction? action]) =>
-      messageState?.show(message);
+      messageState.show(message);
+
+  /// Shows a global custom [snackBar]using the [HarpyMessage].
+  void showCustom(SnackBar snackBar) => messageState.showCustom(snackBar);
 }

--- a/lib/misc/image_from_cache.dart
+++ b/lib/misc/image_from_cache.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/painting.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger('imageFromCache');
+
+/// Returns the image data as a [Uint8List] from the [imageCache] if it exists.
+///
+/// The [key] is the [ImageProvider] which is used to map the image data (e.g
+/// a [NetworkImage]).
+///
+/// If the cached image has multiple frames (i.e. a gif), only the first
+/// frame will be returned.
+Future<Uint8List?> imageDataFromCache(Object key) async {
+  try {
+    if (imageCache!.containsKey(key)) {
+      final imageStreamCompleter = imageCache!.putIfAbsent(
+        key,
+        // we don't want to load and cache the image so we just throw an
+        // exception and return null
+        () => throw Exception('image not in cache'),
+      );
+
+      if (imageStreamCompleter != null) {
+        return await _imageStreamHandler(imageStreamCompleter);
+      } else {
+        return null;
+      }
+    } else {
+      _log.fine('image not in cache $key');
+      return null;
+    }
+  } catch (e) {
+    _log.fine('error retrieving image $key');
+    return null;
+  }
+}
+
+Future<Uint8List?> _imageStreamHandler(
+  ImageStreamCompleter imageStreamCompleter,
+) {
+  final completer = Completer<Uint8List?>();
+
+  var listenedOnce = false;
+
+  imageStreamCompleter.addListener(
+    ImageStreamListener((image, _) async {
+      if (listenedOnce) {
+        return;
+      }
+
+      listenedOnce = true;
+
+      _log.info('got cached image');
+
+      final byteData = await image.image.toByteData();
+
+      if (byteData != null) {
+        completer.complete(
+          byteData.buffer.asUint8List(
+            byteData.offsetInBytes,
+            byteData.lengthInBytes,
+          ),
+        );
+      } else {
+        _log.warning('cached image byte data is null');
+        completer.complete();
+      }
+    }, onError: (e, st) {
+      _log.severe('error loading cached image', e, st);
+      completer.complete();
+    }),
+  );
+
+  return completer.future;
+}

--- a/lib/misc/misc.dart
+++ b/lib/misc/misc.dart
@@ -2,6 +2,7 @@ library misc;
 
 export 'changelog_parser.dart';
 export 'harpy_navigator.dart';
+export 'image_from_cache.dart';
 export 'predefined_themes.dart';
 export 'remove_focus.dart';
 export 'scroll_behavior.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,6 @@ dependencies:
   file_picker: ^3.0.1
   firebase_analytics: ^8.0.0
   flutter_displaymode: ^0.3.1-nullsafety.0
-  flutter_downloader: ^1.6.0
   flutter_ffmpeg: ^0.4.0
   flutter_keyboard_visibility: ^5.0.1
   location: ^4.1.1


### PR DESCRIPTION
This PR removes the flutter_download plugin which doesn't download images and videos properly for some users.

The new approach is much simpler without relying on any plugin.

Additionally when downloading an image, we check the flutter image cache before downloading the image to see whether we can save the image directly from the cache without having to make a redundant request.
This will be the case when the user set the `Tweet image quality` setting to use the best quality.