### PR TITLE
Implement tweet character counter

### DIFF
--- a/android/fastlane/metadata/android/free/en-US/changelogs/55.txt
+++ b/android/fastlane/metadata/android/free/en-US/changelogs/55.txt
@@ -1,9 +1,10 @@
 Version 0.6.7
-2021-06-08
+2021-06-xx
 
 · Updated tweet detail screen (replies screen)
 · Added additional tweet infos in the detail screen:
   · Tweet source (Twitter Web, Twitter for iPhone, Harpy for Twitter, etc.)
   · Absolute time of tweet creation
+· Added tweet character limit counter in compose tweet screen
 · Updated font size option to also affect tweet avatar and icon sizes
 · Fixed threads are not displayed correctly sometimes (Thanks Darren!)

--- a/bin/fix_regex_range.dart
+++ b/bin/fix_regex_range.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+/// This fixes regex that has invalid unicode ranges.
+///
+/// The regex found in the twitter-text library
+/// (https://github.com/twitter/twitter-text) contains regex with invalid
+/// unicode ranges (from high to low)
+/// In dart, character ranges always have to start with the lowest character.
+///
+/// Example:
+/// Input:  `\ud83c\udffb\ud83c\udffd-\ud83c\udfff`
+/// Output: `\ud83c\udffb\ud83c\ud83c-\udffd\udfff`
+void main(List<String> arguments) {
+  final elements = arguments[0].split(r'\u');
+
+  for (var i = 0; i < elements.length; i++) {
+    final element = elements[i];
+
+    if (element.endsWith('-')) {
+      // start of range
+      final nextElement = elements[i + 1];
+
+      final start = int.tryParse(element.replaceAll('-', ''), radix: 16);
+      final end = int.tryParse(nextElement, radix: 16);
+
+      if (start != null && end != null && start > end) {
+        elements[i] = '$nextElement-';
+        elements[++i] = element.replaceAll('-', '');
+      }
+    }
+  }
+
+  File('regex.txt').writeAsString(elements.join(r'\u'));
+}

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -20,3 +20,4 @@ export 'twitter/media_type.dart';
 export 'twitter/media_upload_service.dart';
 export 'twitter/media_video_converter.dart';
 export 'twitter/parse_entities.dart';
+export 'twitter/tweet_text_count.dart';

--- a/lib/api/twitter/tweet_text_count.dart
+++ b/lib/api/twitter/tweet_text_count.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/widgets.dart';
+import 'package:harpy/core/core.dart';
+
+/// The count of weighted characters for a tweet.
+///
+/// - Each url counts as 23 characters
+/// - Each emoji counts as 2 characters
+/// - Glyphs defined in [_normalWeightedCharactersRegex] count as 1 character
+///   (including Latin characters)
+/// - Other glyphs including Chinese / Japanese / Korean glyphs count as 2
+///   characters
+int tweetTextCount(String text) {
+  final urls = urlRegex.allMatches(text).length;
+  text = text.replaceAll(urlRegex, '');
+
+  final emojis = _uniqueEmojis(text);
+  text = text.replaceAll(emojiRegex, '');
+
+  final normalWeighted = _normalWeightedCharactersRegex.allMatches(text);
+  text = text.replaceAll(_normalWeightedCharactersRegex, '');
+
+  final urlsLength = urls * 23;
+  final emojisLength = emojis * 2;
+  final normalWeigthedCharacters = normalWeighted.length;
+  final otherCharacters = text.codeUnits.length * 2;
+
+  return urlsLength + emojisLength + normalWeigthedCharacters + otherCharacters;
+}
+
+/// Regex to match the code unit ranges for unicode glyphs that are weighted as
+/// a single character.
+///
+/// The default weight for a character is 2 (e.g. Chinese / Japanese / Korean
+/// characters).
+///
+/// From the twitter-text library config v3
+/// https://github.com/twitter/twitter-text/blob/master/config/v3.json.
+///
+/// For information about unicode glyph ranges, see
+/// https://www.unicodepedia.com/groups/.
+final _normalWeightedCharactersRegex = RegExp(
+  r'[\u0000-\u10FF]|[\u2000-\u200D]|[\u2010-\u201F]|[\u2032-\u2037]',
+);
+
+/// Returns the amount of unique emojis in the [text].
+///
+/// Emojis that consist of emoji sequences with combining glyphs count as a
+/// single emoji.
+///
+/// For example:
+///
+/// Emoji with skin tone modifier:
+/// 🙋🏽 = 1 // 🙋 (U+1F64B) + 🏽 (U+1F3FD)
+///
+/// Emoji sequence using combining glyph (zero-width joiner)
+/// 👨‍🎤 = 1 // 👨 (U+1F468) + U+200D + 🎤 (U+1F3A4)
+int _uniqueEmojis(String text) {
+  var uniqueEmojis = 0;
+
+  final emojiMatches = emojiRegex.allMatches(text);
+
+  if (emojiMatches.isNotEmpty) {
+    try {
+      final emojiGroups = <String>[];
+
+      var prevEnd = -1;
+      var group = -1;
+
+      for (final match in emojiMatches) {
+        final start = match.start;
+        final end = match.end;
+
+        if (start == prevEnd) {
+          emojiGroups[group] += text.substring(start, end);
+        } else {
+          emojiGroups.add(text.substring(start, end));
+          group++;
+        }
+
+        prevEnd = end;
+      }
+
+      for (final emojiGroup in emojiGroups) {
+        uniqueEmojis += Characters(emojiGroup).length;
+      }
+    } catch (e) {
+      // ignore potential parsing errors
+    }
+  }
+
+  return uniqueEmojis;
+}

--- a/lib/components/components.dart
+++ b/lib/components/components.dart
@@ -85,6 +85,7 @@ export 'screens/compose/widget/content/compose_text_field.dart';
 export 'screens/compose/widget/content/compose_trends.dart';
 export 'screens/compose/widget/content/compose_tweet_card.dart';
 export 'screens/compose/widget/content/compose_tweet_card_with_parent.dart';
+export 'screens/compose/widget/content/compose_tweet_max_length.dart';
 export 'screens/compose/widget/post_tweet/post_tweet_dialog.dart';
 export 'screens/following_followers/common/bloc/following_followers_bloc.dart';
 export 'screens/following_followers/common/following_followers_screen.dart';

--- a/lib/components/screens/compose/widget/content/compose_action_row.dart
+++ b/lib/components/screens/compose/widget/content/compose_action_row.dart
@@ -11,7 +11,7 @@ class ComposeTweetActionRow extends StatelessWidget {
     required this.controller,
   });
 
-  final ComposeTextController? controller;
+  final ComposeTextController controller;
 
   @override
   Widget build(BuildContext context) {
@@ -38,15 +38,16 @@ class ComposeTweetActionRow extends StatelessWidget {
           padding: DefaultEdgeInsets.all(),
           icon: const Icon(CupertinoIcons.at),
           iconSize: 20,
-          onTap: () => controller!.insertString('@'),
+          onTap: () => controller.insertString('@'),
         ),
         defaultSmallHorizontalSpacer,
         HarpyButton.flat(
           padding: DefaultEdgeInsets.all(),
           text: const Text('#', style: TextStyle(fontSize: 20)),
-          onTap: () => controller!.insertString('#'),
+          onTap: () => controller.insertString('#'),
         ),
         const Spacer(),
+        ComposeTweetMaxLenght(controller: controller),
         PostTweetButton(controller: controller),
       ],
     );

--- a/lib/components/screens/compose/widget/content/compose_mentions.dart
+++ b/lib/components/screens/compose/widget/content/compose_mentions.dart
@@ -12,7 +12,7 @@ class ComposeTweetMentions extends StatelessWidget {
     required this.controller,
   });
 
-  final TextEditingController? controller;
+  final ComposeTextController? controller;
 
   @override
   Widget build(BuildContext context) {
@@ -22,8 +22,7 @@ class ComposeTweetMentions extends StatelessWidget {
       create: (context) => MentionSuggestionsBloc(
         authenticatedUser: authBloc.authenticatedUser!,
       ),
-      child:
-          MentionSuggestions(controller: controller as ComposeTextController?),
+      child: MentionSuggestions(controller: controller),
     );
   }
 }

--- a/lib/components/screens/compose/widget/content/compose_tweet_card.dart
+++ b/lib/components/screens/compose/widget/content/compose_tweet_card.dart
@@ -49,11 +49,11 @@ class _ComposeTweetCardState extends State<ComposeTweetCard> {
 
   @override
   void dispose() {
-    super.dispose();
-
     _keyboardListener.cancel();
     _controller?.dispose();
     _focusNode.dispose();
+
+    super.dispose();
   }
 
   Widget _buildMedia(ComposeState state) {
@@ -92,7 +92,7 @@ class _ComposeTweetCardState extends State<ComposeTweetCard> {
                 ),
               ),
             ),
-            ComposeTweetActionRow(controller: _controller),
+            ComposeTweetActionRow(controller: _controller!),
           ],
         ),
       ),

--- a/lib/components/screens/compose/widget/content/compose_tweet_max_length.dart
+++ b/lib/components/screens/compose/widget/content/compose_tweet_max_length.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:harpy/api/api.dart';
+import 'package:harpy/components/components.dart';
+
+/// Builds the count of weighted tweet characters in the composed tweet with the
+/// max length of 280 characters.
+class ComposeTweetMaxLenght extends StatefulWidget {
+  const ComposeTweetMaxLenght({
+    required this.controller,
+  });
+
+  final ComposeTextController controller;
+
+  @override
+  _ComposeTweetMaxLenghtState createState() => _ComposeTweetMaxLenghtState();
+}
+
+class _ComposeTweetMaxLenghtState extends State<ComposeTweetMaxLenght> {
+  late String _text;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _text = widget.controller.text;
+    widget.controller.addListener(_listener);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_listener);
+
+    super.dispose();
+  }
+
+  void _listener() {
+    final text = widget.controller.text;
+
+    if (text != _text) {
+      setState(() {
+        _text = text;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final count = tweetTextCount(widget.controller.text);
+
+    final style = count <= 280
+        ? theme.textTheme.bodyText1
+        : theme.textTheme.bodyText1?.copyWith(color: theme.errorColor);
+
+    return Text('$count / 280', style: style);
+  }
+}

--- a/lib/core/regex/common_regex.dart
+++ b/lib/core/regex/common_regex.dart
@@ -1,11 +1,21 @@
 /// Matches any whitespace.
-final RegExp whitespaceRegex = RegExp(r'\s');
+final whitespaceRegex = RegExp(r'\s');
 
 /// Matches a ISO 8601 formatted date.
-final RegExp dateRegex = RegExp(r'^\d{4}-\d{2}-\d{2}$');
+final dateRegex = RegExp(r'^\d{4}-\d{2}-\d{2}$');
 
 /// Matches text inside of a html tag.
 ///
 /// Example:
-/// `<a href="url">Some text</a>` matches: `Some text`.
-final RegExp htmlTagRegex = RegExp(r'(?<=>)([\w\s]+)(?=<\/)');
+/// `<a href='url'>Some text</a>` matches: `Some text`.
+final htmlTagRegex = RegExp(r'(?<=>)([\w\s]+)(?=<\/)');
+
+final urlRegex = RegExp(
+  r'((https?:www\.)|(https?:\/\/)|(www\.))[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9]{1,6}(\/[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)?',
+);
+
+/// Matches all known Unicode Emoji sequences as specified by
+/// http://www.unicode.org/reports/tr51/.
+final emojiRegex = RegExp(
+  r'(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])',
+);

--- a/test/unit_tests/core/api/tweet_text_count_test.dart
+++ b/test/unit_tests/core/api/tweet_text_count_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:harpy/api/api.dart';
+
+void main() {
+  group('tweet text count', () {
+    test('counts each url as 23 characters', () {
+      final count = tweetTextCount(
+        'this tweet is rad! check out https://www.robertodoering.com and '
+        'www.flutter.dev!',
+      );
+
+      const part1 = 'this tweet is rad! check out ';
+      const part2 = ' and ';
+      const part3 = '!';
+
+      expect(
+        count,
+        equals(part1.length + part2.length + part3.length + 23 * 2),
+      );
+    });
+
+    test(
+        'counts emojis with and without combining modifiers as '
+        '2 characters each', () {
+      final count = tweetTextCount(
+        // 👾 (U+1F47E)
+        '👾'
+        // Emoji with skin tone modifier
+        // 🙋 (U+1F64B) + 🏽 (U+1F3FD)
+        '🙋🏽'
+        // Emoji sequence using combining glyph (zero-width joiner)
+        // 👨 (U+1F468) + U+200D + 🎤 (U+1F3A4)
+        '👨‍🎤'
+        // Emoji sequence using multiple combining glyphs (zero-width joiners)
+        // 👨 (U+1F468) + U+200D + 👩 (U+1F469) + U+200D + 👧 (U+1F467) +
+        // U+200D + 👦 (U+1F466)
+        '👨‍👩‍👧‍👦',
+      );
+
+      expect(count, equals(8));
+    });
+
+    test('counts special characters as 2', () {
+      final count = tweetTextCount('幽閉　利口　逝く前に');
+
+      expect(count, equals(20));
+    });
+
+    test('counts normal-weighted characters as 1', () {
+      final count = tweetTextCount('never gonna give you up');
+
+      expect(count, equals(23));
+    });
+  });
+}

--- a/test/unit_tests/core/regex/common_regex_test.dart
+++ b/test/unit_tests/core/regex/common_regex_test.dart
@@ -9,4 +9,46 @@ void main() {
     expect(dateRegex.hasMatch('abcd-ef-gh'), isFalse);
     expect(dateRegex.hasMatch('1-2-3'), isFalse);
   });
+
+  test('htmlTagRegex matches html tag value', () {
+    final match = htmlTagRegex.firstMatch('<html>value</html>');
+
+    expect(match?.group(0), equals('value'));
+    expect(htmlTagRegex.hasMatch('<html>value<a>><>'), isFalse);
+  });
+
+  test('urlRegex matches urls', () {
+    final match1 = urlRegex.firstMatch(
+      'text https://robertodoering.com more text',
+    );
+
+    final match2 = urlRegex.firstMatch(
+      'text https://robertodoering.com.',
+    );
+
+    final match3 = urlRegex.firstMatch(
+      'text https://robertodoering.com/this/path/doesnt/exist.html!',
+    );
+
+    expect(match1?.group(0), equals('https://robertodoering.com'));
+    expect(match2?.group(0), equals('https://robertodoering.com'));
+    expect(
+      match3?.group(0),
+      equals('https://robertodoering.com/this/path/doesnt/exist.html'),
+    );
+    expect(urlRegex.hasMatch('http://robertodoering.com'), isTrue);
+    expect(urlRegex.hasMatch('www.robertodoering.com'), isTrue);
+    expect(urlRegex.hasMatch('https://robertodoering'), isFalse);
+    expect(urlRegex.hasMatch('www.robertodoering'), isFalse);
+    expect(urlRegex.hasMatch('robertodoering.com'), isFalse);
+  });
+
+  test('emojiRegex matches emojis', () {
+    expect(emojiRegex.hasMatch('👾'), isTrue);
+    expect(emojiRegex.hasMatch('🙋🏽'), isTrue);
+    expect(emojiRegex.hasMatch('👨‍🎤'), isTrue);
+    expect(emojiRegex.hasMatch('👨‍👩‍👧‍👦'), isTrue);
+    expect(emojiRegex.hasMatch(':)'), isFalse);
+    expect(emojiRegex.hasMatch('a b c d e f g 1 2 3'), isFalse);
+  });
 }


### PR DESCRIPTION
- Added `tweetTextCount` to count the characters when composing tweet, taking the weighted characters in account as described in https://developer.twitter.com/en/docs/counting-characters.
- The current character count and limit will now be displayed when composing a tweet
  - When reaching the limit, the UI doesn't stop the user from actually trying to send the tweet.
Instead the server will respond with an error which is displayed to the user.
This ensures that in cases where we are counting wrong or if the tweet character counting changes in the future, the user will still be able to tweet.

Closes #334