### PR TITLE
Add harpy page route & Cleanup navigation

### DIFF
--- a/lib/components/common/authentication/bloc/authentication_event.dart
+++ b/lib/components/common/authentication/bloc/authentication_event.dart
@@ -48,19 +48,16 @@ abstract class AuthenticationEvent {
       // unable to authenticate user, allow to retry in case of temporary
       // network error
       final retry = await showDialog<bool>(
-        context: app<HarpyNavigator>().state!.context,
+        context: app<HarpyNavigator>().state.context,
         builder: (_) => const HarpyDialog(
           title: Text('login'),
-          content: Text('unable to initialize authenticated user'),
+          content: Text(
+            'unable to initialize authenticated user\n\n'
+            'check your connection and try again',
+          ),
           actions: <Widget>[
-            DialogAction<bool>(
-              result: false,
-              text: 'cancel',
-            ),
-            DialogAction<bool>(
-              result: true,
-              text: 'retry',
-            ),
+            DialogAction<bool>(result: false, text: 'cancel'),
+            DialogAction<bool>(result: true, text: 'retry'),
           ],
         ),
       );
@@ -199,16 +196,16 @@ class LoginEvent extends AuthenticationEvent {
   static final Logger _log = Logger('LoginEvent');
 
   Future<Uri?> _webviewNavigation(TwitterLoginWebview webview) async {
-    return app<HarpyNavigator>().state!.push<Uri>(
-          CupertinoPageRoute<Uri>(
-            builder: (_) => HarpyScaffold(
-              title: 'login',
-              buildSafeArea: true,
-              body: webview,
-            ),
-            settings: const RouteSettings(name: 'login'),
-          ),
-        );
+    return app<HarpyNavigator>().push<Uri>(
+      CupertinoPageRoute<Uri>(
+        builder: (_) => HarpyScaffold(
+          title: 'login',
+          buildSafeArea: true,
+          body: webview,
+        ),
+        settings: const RouteSettings(name: 'login'),
+      ),
+    );
   }
 
   Future<TwitterAuthResult> _authenticateWithWebview(

--- a/lib/components/common/tweet/widgets/overlay/media_overlay.dart
+++ b/lib/components/common/tweet/widgets/overlay/media_overlay.dart
@@ -112,9 +112,9 @@ class MediaOverlay extends StatefulWidget {
   }) {
     final mediaUrl = tweet.downloadMediaUrl();
 
-    app<HarpyNavigator>().pushRoute(
+    app<HarpyNavigator>().push(
       HeroDialogRoute<void>(
-        onBackgroundTap: () => app<HarpyNavigator>().state!.maybePop(),
+        onBackgroundTap: app<HarpyNavigator>().maybePop,
         builder: (context) => MediaOverlay(
           tweet: tweet,
           tweetBloc: tweetBloc,
@@ -177,15 +177,13 @@ class _MediaOverlayState extends State<MediaOverlay>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    app<HarpyNavigator>()
-        .routeObserver
-        .subscribe(this, ModalRoute.of(context) as PageRoute<dynamic>);
+    harpyRouteObserver.subscribe(this, ModalRoute.of(context)!);
   }
 
   @override
   void dispose() {
     super.dispose();
-    app<HarpyNavigator>().routeObserver.unsubscribe(this);
+    harpyRouteObserver.unsubscribe(this);
   }
 
   @override
@@ -262,7 +260,7 @@ class _MediaOverlayState extends State<MediaOverlay>
 
     if (widget.enableDismissible) {
       child = CustomDismissible(
-        onDismissed: () => app<HarpyNavigator>().state!.maybePop(),
+        onDismissed: app<HarpyNavigator>().maybePop,
         child: child,
       );
     }

--- a/lib/components/common/tweet/widgets/tweet/content/tweet_actions_bottom_sheet.dart
+++ b/lib/components/common/tweet/widgets/tweet/content/tweet_actions_bottom_sheet.dart
@@ -62,7 +62,7 @@ void showTweetActionsBottomSheet(
             bloc.add(DeleteTweet(onDeleted: () {
               homeTimelineBloc.add(RemoveFromHomeTimeline(tweet: bloc.tweet));
             }));
-            app<HarpyNavigator>().state!.maybePop();
+            app<HarpyNavigator>().maybePop();
           },
         ),
       if (showReply)
@@ -70,7 +70,7 @@ void showTweetActionsBottomSheet(
           leading: const Icon(CupertinoIcons.reply),
           title: const Text('reply'),
           onTap: () async {
-            await app<HarpyNavigator>().state!.maybePop();
+            await app<HarpyNavigator>().maybePop();
             app<HarpyNavigator>().pushComposeScreen(
               inReplyToStatus: tweet,
             );
@@ -81,7 +81,7 @@ void showTweetActionsBottomSheet(
         title: const Text('open tweet externally'),
         onTap: () {
           launchUrl(tweet.tweetUrl);
-          app<HarpyNavigator>().state!.maybePop();
+          app<HarpyNavigator>().maybePop();
         },
       ),
       ListTile(
@@ -91,7 +91,7 @@ void showTweetActionsBottomSheet(
         onTap: () {
           Clipboard.setData(ClipboardData(text: tweet.visibleText));
           app<MessageService>().show('copied tweet text');
-          app<HarpyNavigator>().state!.maybePop();
+          app<HarpyNavigator>().maybePop();
         },
       ),
       ListTile(
@@ -99,7 +99,7 @@ void showTweetActionsBottomSheet(
         title: const Text('share tweet'),
         onTap: () {
           Share.share(tweet.tweetUrl);
-          app<HarpyNavigator>().state!.maybePop();
+          app<HarpyNavigator>().maybePop();
         },
       ),
     ],

--- a/lib/components/components.dart
+++ b/lib/components/components.dart
@@ -244,6 +244,7 @@ export 'widgets/misc/translated_text.dart';
 export 'widgets/misc/twitter_text.dart';
 export 'widgets/misc/will_pop_harpy.dart';
 export 'widgets/routes/fade_route.dart';
+export 'widgets/routes/harpy_page_route.dart';
 export 'widgets/routes/hero_dialog_route.dart';
 export 'widgets/video_player/harpy_gif_player.dart';
 export 'widgets/video_player/harpy_video_player.dart';

--- a/lib/components/screens/compose/widget/post_tweet/post_tweet_dialog.dart
+++ b/lib/components/screens/compose/widget/post_tweet/post_tweet_dialog.dart
@@ -92,9 +92,7 @@ class PostTweetDialogContent extends StatelessWidget {
         actions: <Widget>[
           DialogAction<void>(
             text: 'ok',
-            onTap: state.inProgress
-                ? null
-                : () => app<HarpyNavigator>().state!.maybePop(),
+            onTap: state.inProgress ? null : app<HarpyNavigator>().maybePop,
           )
         ],
       ),

--- a/lib/components/screens/home/home_screen.dart
+++ b/lib/components/screens/home/home_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:harpy/components/components.dart';
-import 'package:harpy/core/core.dart';
 import 'package:harpy/misc/misc.dart';
 import 'package:provider/provider.dart';
 
@@ -28,15 +27,13 @@ class _HomeScreenState extends State<HomeScreen> with RouteAware {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    app<HarpyNavigator>()
-        .routeObserver
-        .subscribe(this, ModalRoute.of(context) as PageRoute<dynamic>);
+    harpyRouteObserver.subscribe(this, ModalRoute.of(context)!);
   }
 
   @override
   void dispose() {
+    harpyRouteObserver.unsubscribe(this);
     super.dispose();
-    app<HarpyNavigator>().routeObserver.unsubscribe(this);
   }
 
   @override

--- a/lib/components/screens/home/home_tab_customization/home_tab_customization_screen.dart
+++ b/lib/components/screens/home/home_tab_customization/home_tab_customization_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:harpy/components/components.dart';
-import 'package:harpy/core/core.dart';
 import 'package:harpy/harpy.dart';
 import 'package:harpy/misc/misc.dart';
 import 'package:provider/provider.dart';
@@ -39,15 +38,13 @@ class _HomeTabCustomizationScreenState extends State<HomeTabCustomizationScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    app<HarpyNavigator>()
-        .routeObserver
-        .subscribe(this, ModalRoute.of(context) as PageRoute<dynamic>);
+    harpyRouteObserver.subscribe(this, ModalRoute.of(context)!);
   }
 
   @override
   void dispose() {
+    harpyRouteObserver.unsubscribe(this);
     super.dispose();
-    app<HarpyNavigator>().routeObserver.unsubscribe(this);
   }
 
   @override

--- a/lib/components/screens/home/widgets/home_drawer.dart
+++ b/lib/components/screens/home/widgets/home_drawer.dart
@@ -27,7 +27,7 @@ class HomeDrawer extends StatelessWidget {
                 leading: const Icon(CupertinoIcons.person),
                 title: const Text('Profile'),
                 onTap: () async {
-                  await app<HarpyNavigator>().state!.maybePop();
+                  await app<HarpyNavigator>().maybePop();
                   app<HarpyNavigator>().pushUserProfile(
                     screenName: authBloc.authenticatedUser!.handle,
                   );
@@ -39,7 +39,7 @@ class HomeDrawer extends StatelessWidget {
                 leading: const Icon(CupertinoIcons.list_bullet),
                 title: const Text('Lists'),
                 onTap: () async {
-                  await app<HarpyNavigator>().state!.maybePop();
+                  await app<HarpyNavigator>().maybePop();
                   app<HarpyNavigator>().pushShowListsScreen();
                 },
               ),
@@ -51,7 +51,7 @@ class HomeDrawer extends StatelessWidget {
                 leading: const Icon(FeatherIcons.settings),
                 title: const Text('Settings'),
                 onTap: () async {
-                  await app<HarpyNavigator>().state!.maybePop();
+                  await app<HarpyNavigator>().maybePop();
                   app<HarpyNavigator>().pushNamed(SettingsScreen.route);
                 },
               ),
@@ -73,7 +73,7 @@ class HomeDrawer extends StatelessWidget {
                 leading: const FlareIcon.harpyLogo(offset: Offset(-4, 0)),
                 title: const Text('About'),
                 onTap: () async {
-                  await app<HarpyNavigator>().state!.maybePop();
+                  await app<HarpyNavigator>().maybePop();
                   app<HarpyNavigator>().pushNamed(AboutScreen.route);
                 },
               ),
@@ -89,7 +89,7 @@ class HomeDrawer extends StatelessWidget {
                   ),
                 ),
                 onTap: () async {
-                  await app<HarpyNavigator>().state!.maybePop();
+                  await app<HarpyNavigator>().maybePop();
                   app<HarpyNavigator>().pushNamed(BetaInfoScreen.route);
                 },
               ),

--- a/lib/components/screens/user_profile/widgets/content/user_banner.dart
+++ b/lib/components/screens/user_profile/widgets/content/user_banner.dart
@@ -17,7 +17,7 @@ class UserBanner extends StatelessWidget {
     final url = bloc.user!.appropriateUserBannerUrl;
 
     return CustomDismissible(
-      onDismissed: () => app<HarpyNavigator>().state!.maybePop(),
+      onDismissed: app<HarpyNavigator>().maybePop,
       child: Center(
         child: Hero(
           tag: url,
@@ -37,9 +37,9 @@ class UserBanner extends StatelessWidget {
 
       return GestureDetector(
         onTap: () {
-          app<HarpyNavigator>().pushRoute(
+          app<HarpyNavigator>().push(
             HeroDialogRoute<void>(
-              onBackgroundTap: () => app<HarpyNavigator>().state!.maybePop(),
+              onBackgroundTap: app<HarpyNavigator>().maybePop,
               builder: (_) => _buildDialogImage(),
             ),
           );

--- a/lib/components/screens/user_profile/widgets/content/user_info.dart
+++ b/lib/components/screens/user_profile/widgets/content/user_info.dart
@@ -44,11 +44,11 @@ class UserProfileInfo extends StatelessWidget {
   /// possible if the full screen image has to be loaded first).
   Widget _buildAvatar() {
     return GestureDetector(
-      onTap: () => app<HarpyNavigator>().pushRoute(
+      onTap: () => app<HarpyNavigator>().push(
         HeroDialogRoute<void>(
-          onBackgroundTap: app<HarpyNavigator>().state!.maybePop,
+          onBackgroundTap: app<HarpyNavigator>().maybePop,
           builder: (_) => CustomDismissible(
-            onDismissed: app<HarpyNavigator>().state!.maybePop,
+            onDismissed: app<HarpyNavigator>().maybePop,
             child: HarpyMediaGallery.builder(
               itemCount: 1,
               heroTagBuilder: (_) => bloc.user,

--- a/lib/components/settings/common/widgets/radio_dialog_tile.dart
+++ b/lib/components/settings/common/widgets/radio_dialog_tile.dart
@@ -78,7 +78,7 @@ class RadioDialogTile<T> extends StatelessWidget {
               dense: denseRadioTiles,
               onChanged: (value) async {
                 unawaited(HapticFeedback.lightImpact());
-                await app<HarpyNavigator>().state!.maybePop();
+                await app<HarpyNavigator>().maybePop();
                 onChanged?.call(value);
               },
             )

--- a/lib/components/settings/custom_theme/bloc/custom_theme_event.dart
+++ b/lib/components/settings/custom_theme/bloc/custom_theme_event.dart
@@ -209,7 +209,7 @@ class SaveCustomTheme extends CustomThemeEvent {
 
     yield SavedCustomThemeState();
 
-    app<HarpyNavigator>().state!.pop();
+    app<HarpyNavigator>().pop();
   }
 }
 
@@ -248,6 +248,6 @@ class DeleteCustomTheme extends CustomThemeEvent {
 
     yield DeletedCustomThemeState();
 
-    app<HarpyNavigator>().state!.pop();
+    app<HarpyNavigator>().pop();
   }
 }

--- a/lib/components/settings/theme_selection/theme_selection_screen.dart
+++ b/lib/components/settings/theme_selection/theme_selection_screen.dart
@@ -19,15 +19,13 @@ class _ThemeSelectionScreenState extends State<ThemeSelectionScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    app<HarpyNavigator>()
-        .routeObserver
-        .subscribe(this, ModalRoute.of(context) as PageRoute<dynamic>);
+    harpyRouteObserver.subscribe(this, ModalRoute.of(context)!);
   }
 
   @override
   void dispose() {
+    harpyRouteObserver.unsubscribe(this);
     super.dispose();
-    app<HarpyNavigator>().routeObserver.unsubscribe(this);
   }
 
   @override

--- a/lib/components/widgets/dialogs/changelog_dialog.dart
+++ b/lib/components/widgets/dialogs/changelog_dialog.dart
@@ -40,7 +40,7 @@ class ChangelogDialog extends StatelessWidget {
       actions: <Widget>[
         DialogAction<void>(
           text: 'ok',
-          onTap: () => app<HarpyNavigator>().state!.maybePop(),
+          onTap: () => app<HarpyNavigator>().maybePop(),
         )
       ],
     );

--- a/lib/components/widgets/dialogs/color_picker_dialog.dart
+++ b/lib/components/widgets/dialogs/color_picker_dialog.dart
@@ -34,7 +34,7 @@ class _ColorPickerDialogState extends State<ColorPickerDialog> {
       DialogAction<void>(
         text: 'select',
         onTap: () {
-          app<HarpyNavigator>().state!.pop(_color);
+          app<HarpyNavigator>().pop(_color);
         },
       ),
     ];

--- a/lib/components/widgets/filter/filter_drawer.dart
+++ b/lib/components/widgets/filter/filter_drawer.dart
@@ -59,7 +59,7 @@ class FilterDrawer extends StatelessWidget {
                     backgroundColor: theme.cardColor,
                     dense: true,
                     onTap: () async {
-                      await app<HarpyNavigator>().state!.maybePop();
+                      await app<HarpyNavigator>().maybePop();
                       onSearch();
                     },
                   ),

--- a/lib/components/widgets/list/scroll_direction_listener.dart
+++ b/lib/components/widgets/list/scroll_direction_listener.dart
@@ -48,15 +48,13 @@ class _ScrollDirectionListenerState extends State<ScrollDirectionListener>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    app<HarpyNavigator>()
-        .routeObserver
-        .subscribe(this, ModalRoute.of(context) as PageRoute<dynamic>);
+    harpyRouteObserver.subscribe(this, ModalRoute.of(context)!);
   }
 
   @override
   void dispose() {
+    harpyRouteObserver.unsubscribe(this);
     super.dispose();
-    app<HarpyNavigator>().routeObserver.unsubscribe(this);
   }
 
   @override

--- a/lib/components/widgets/misc/twitter_text.dart
+++ b/lib/components/widgets/misc/twitter_text.dart
@@ -44,7 +44,7 @@ void defaultOnUrlLongPress(BuildContext context, UrlData url) {
         title: const Text('open url externally'),
         onTap: () {
           launchUrl(url.expandedUrl);
-          app<HarpyNavigator>().state!.maybePop();
+          app<HarpyNavigator>().maybePop();
         },
       ),
       ListTile(
@@ -52,7 +52,7 @@ void defaultOnUrlLongPress(BuildContext context, UrlData url) {
         title: const Text('copy url text'),
         onTap: () {
           Clipboard.setData(ClipboardData(text: url.expandedUrl));
-          app<HarpyNavigator>().state!.maybePop();
+          app<HarpyNavigator>().maybePop();
         },
       ),
       ListTile(
@@ -60,7 +60,7 @@ void defaultOnUrlLongPress(BuildContext context, UrlData url) {
         title: const Text('share url'),
         onTap: () {
           Share.share(url.expandedUrl);
-          app<HarpyNavigator>().state!.maybePop();
+          app<HarpyNavigator>().maybePop();
         },
       ),
     ],

--- a/lib/components/widgets/routes/harpy_page_route.dart
+++ b/lib/components/widgets/routes/harpy_page_route.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/cupertino.dart';
+
+/// A page route that uses the [CupertinoPageTransition] and
+/// [CupertinoFullscreenDialogTransition] to transition between pages.
+///
+/// Unlike the [CupertinoPageRoute], no back gesture detector is built at the
+/// edge of the screen since it conflicts with the native android back gesture.
+class HarpyPageRoute<T> extends PageRoute<T> with HarpyRouteTransitionMixin<T> {
+  HarpyPageRoute({
+    required this.builder,
+    RouteSettings? settings,
+    this.maintainState = true,
+    bool fullscreenDialog = false,
+  }) : super(settings: settings, fullscreenDialog: fullscreenDialog);
+
+  final WidgetBuilder builder;
+
+  @override
+  final bool maintainState;
+
+  @override
+  Widget buildContent(BuildContext context) => builder(context);
+}
+
+mixin HarpyRouteTransitionMixin<T> on PageRoute<T> {
+  /// Builds the primary contents of the route.
+  @protected
+  Widget buildContent(BuildContext context);
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 400);
+
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  String? get barrierLabel => null;
+
+  @override
+  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
+    return nextRoute is HarpyRouteTransitionMixin &&
+        !nextRoute.fullscreenDialog;
+  }
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    return Semantics(
+      scopesRoute: true,
+      explicitChildNodes: true,
+      child: buildContent(context),
+    );
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    if (fullscreenDialog) {
+      return CupertinoFullscreenDialogTransition(
+        primaryRouteAnimation: animation,
+        secondaryRouteAnimation: secondaryAnimation,
+        linearTransition: false,
+        child: child,
+      );
+    } else {
+      return CupertinoPageTransition(
+        primaryRouteAnimation: animation,
+        secondaryRouteAnimation: secondaryAnimation,
+        linearTransition: false,
+        child: child,
+      );
+    }
+  }
+}

--- a/lib/components/widgets/video_player/harpy_video_player_model.dart
+++ b/lib/components/widgets/video_player/harpy_video_player_model.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
 import 'package:harpy/misc/misc.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:video_player/video_player.dart';
 
 /// Actions that a user can take on a video.
@@ -168,12 +167,12 @@ class HarpyVideoPlayerModel extends ChangeNotifier {
   ///
   /// The system ui overlay will be hidden while the video is played in
   /// fullscreen.
-  Future<void> _pushFullscreen() async {
+  void _pushFullscreen() {
     _fullscreen = true;
 
-    unawaited(SystemChrome.setEnabledSystemUIOverlays(<SystemUiOverlay>[]));
+    SystemChrome.setEnabledSystemUIOverlays(<SystemUiOverlay>[]);
 
-    app<HarpyNavigator>().pushRoute(
+    app<HarpyNavigator>().push(
       HeroDialogRoute<void>(
         onBackgroundTap: toggleFullscreen,
         builder: (_) => VideoFullscreen(this),
@@ -184,13 +183,13 @@ class HarpyVideoPlayerModel extends ChangeNotifier {
   /// Exits the fullscreen video.
   ///
   /// The system ui overlays will be shown again.
-  Future<void> _popFullscreen() async {
+  void _popFullscreen() {
     _fullscreen = false;
 
-    unawaited(SystemChrome.setEnabledSystemUIOverlays(SystemUiOverlay.values));
+    SystemChrome.setEnabledSystemUIOverlays(SystemUiOverlay.values);
 
     if (hasListeners) {
-      unawaited(app<HarpyNavigator>().state!.maybePop());
+      app<HarpyNavigator>().maybePop();
       notifyListeners();
     }
   }

--- a/lib/harpy.dart
+++ b/lib/harpy.dart
@@ -33,7 +33,7 @@ class Harpy extends StatelessWidget {
             analytics: app<AnalyticsService>().analytics,
             nameExtractor: screenNameExtractor,
           ),
-          app<HarpyNavigator>().routeObserver,
+          harpyRouteObserver,
         ],
         home: const SplashScreen(),
         builder: (_, child) => ScrollConfiguration(

--- a/lib/misc/harpy_navigator.dart
+++ b/lib/misc/harpy_navigator.dart
@@ -5,7 +5,9 @@ import 'package:harpy/components/components.dart';
 import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 import 'package:logging/logging.dart';
 
-/// The [RouteType] determines what [PageRoute] is used for the new route.
+final Logger _log = Logger('HarpyNavigator');
+
+///Determines what [PageRoute] is used for the new route.
 ///
 /// This determines the transition animation for the new route.
 enum RouteType {
@@ -13,33 +15,32 @@ enum RouteType {
   fade,
 }
 
-final Logger _log = Logger('HarpyNavigator');
+/// A [Navigator] observer that is used to notify [RouteAware]s of changes to
+/// the state of their [Route].
+final harpyRouteObserver = RouteObserver<ModalRoute<dynamic>>();
 
 /// The [HarpyNavigator] contains the [Navigator] key used by the root
-/// [MaterialApp]. This allows for navigation without access to the
-/// [BuildContext].
+/// [MaterialApp].
+///
+/// This allows for navigation without access to the [BuildContext].
 class HarpyNavigator {
   final GlobalKey<NavigatorState> key = GlobalKey<NavigatorState>();
 
-  /// A [Navigator] observer that is used to notify [RouteAware]s of changes to
-  /// the state of their [Route].
-  final RouteObserver<PageRoute<dynamic>> routeObserver =
-      RouteObserver<PageRoute<dynamic>>();
+  NavigatorState get state => key.currentState!;
 
-  NavigatorState? get state => key.currentState;
+  void pop<T extends Object>([T? result]) => state.pop<T>(result);
 
-  /// A convenience method to push a new [route] to the [Navigator].
-  void pushRoute(Route<void> route) {
-    key.currentState!.push<void>(route);
-  }
+  Future<bool> maybePop<T extends Object>([T? result]) =>
+      state.maybePop(result);
 
-  /// A convenience method to push a named replacement route.
+  Future<T?> push<T>(Route<T> route) => state.push<T>(route);
+
   void pushReplacementNamed(
     String route, {
     RouteType type = RouteType.defaultRoute,
     Map<String, dynamic>? arguments,
   }) {
-    key.currentState!.pushReplacementNamed<void, void>(
+    state.pushReplacementNamed<void, void>(
       route,
       arguments: <String, dynamic>{
         'routeType': type,
@@ -48,13 +49,12 @@ class HarpyNavigator {
     );
   }
 
-  /// A convenience method to push a named route.
   void pushNamed(
     String route, {
     RouteType type = RouteType.defaultRoute,
     Map<String, dynamic>? arguments,
   }) {
-    key.currentState!.pushNamed<void>(
+    state.pushNamed<void>(
       route,
       arguments: <String, dynamic>{
         'routeType': type,
@@ -63,7 +63,6 @@ class HarpyNavigator {
     );
   }
 
-  /// Pushes a [UserProfileScreen] for the user with the [screenName].
   void pushUserProfile({
     required String screenName,
     RouteSettings? currentRoute,
@@ -86,7 +85,6 @@ class HarpyNavigator {
     );
   }
 
-  /// Pushes a [CustomThemeScreen] with the [themeData] for [themeId].
   void pushCustomTheme({
     required HarpyThemeData themeData,
     required int themeId,
@@ -100,8 +98,6 @@ class HarpyNavigator {
     );
   }
 
-  /// Pushes a [FollowingScreen] with the following users for the user with the
-  /// [userId].
   void pushFollowingScreen({
     required String userId,
   }) {
@@ -110,8 +106,6 @@ class HarpyNavigator {
     });
   }
 
-  /// Pushes a [FollowersScreen] with the followers for the user with the
-  /// [userId].
   void pushFollowersScreen({
     required String userId,
   }) {
@@ -128,7 +122,6 @@ class HarpyNavigator {
     });
   }
 
-  /// Pushes a [TweetSearchScreen] with an optional [initialSearchQuery].
   void pushTweetSearchScreen({
     String? initialSearchQuery,
   }) {
@@ -137,7 +130,6 @@ class HarpyNavigator {
     });
   }
 
-  /// Pushes a [ComposeScreen] with an optional reply status or quoted tweet.
   void pushComposeScreen({
     TweetData? inReplyToStatus,
     TweetData? quotedTweet,
@@ -165,7 +157,6 @@ class HarpyNavigator {
     });
   }
 
-  /// Pushes a [ListTimelineScreen] that shows the tweets for the [list].
   void pushListTimelineScreen({
     required TwitterListData list,
   }) {
@@ -174,7 +165,6 @@ class HarpyNavigator {
     });
   }
 
-  /// Pushes a [ListMembersScreen] that shows the members for the [list].
   void pushListMembersScreen({
     required TwitterListData list,
   }) {
@@ -183,7 +173,6 @@ class HarpyNavigator {
     });
   }
 
-  /// Pushes a [HomeTabCustomizationScreen].
   void pushHomeTabCustomizationScreen({
     required HomeTabModel model,
   }) {
@@ -322,7 +311,7 @@ Route<dynamic> onGenerateRoute(RouteSettings settings) {
         settings: RouteSettings(name: routeName, arguments: arguments),
       );
     case RouteType.defaultRoute:
-      return CupertinoPageRoute<void>(
+      return HarpyPageRoute<void>(
         builder: (_) => screen,
         settings: RouteSettings(name: routeName, arguments: arguments),
       );

--- a/test/widget_tests/components/common/misc/changelog_dialog_test.dart
+++ b/test/widget_tests/components/common/misc/changelog_dialog_test.dart
@@ -27,7 +27,7 @@ void main() {
     );
     app.registerLazySingleton<ChangelogParser>(() => ChangelogParser());
 
-    when(app<HarpyNavigator>().routeObserver).thenReturn(MockRouteObserver());
+    when(harpyRouteObserver).thenReturn(MockRouteObserver());
   });
 
   tearDown(app.reset);


### PR DESCRIPTION
I decided against adding a global horizontal swipe gesture for dismissing stacked routes. The main problem with it was that it conflicts with the horizontal tab view navigation in the user screen.

Instead we use a `HarpyPageRoute` which uses the cupertino page transitions but doesn't build the ios style back gesture detector since it conflicts with the native android back gesture.

Closes #340