### PR TITLE
Update home app bar

### DIFF
--- a/.vscode/bloc.code-snippets
+++ b/.vscode/bloc.code-snippets
@@ -1,8 +1,27 @@
 {
+	"Media query": {
+		"prefix": "mqof",
+		"scope": "dart",
+		"body": "final mediaQuery = MediaQuery.of(context);"
+	},
+	"Theme": {
+		"prefix": "thof",
+		"scope": "dart",
+		"body": "final theme = Theme.of(context);"
+	},
+	"HarpyTheme": {
+		"prefix": "harpythof",
+		"scope": "dart",
+		"body": "final harpyTheme = context.watch<HarpyTheme>();"
+	},
+	"Config": {
+		"prefix": "configof",
+		"scope": "dart",
+		"body": "final config = context.watch<ConfigCubit>().state;"
+	},
 	"Bloc base": {
 		"prefix": "bloc",
 		"scope": "dart",
-		"description": "Create a new bloc",
 		"body": [
 			"import 'package:equatable/equatable.dart';",
 			"import 'package:flutter_bloc/flutter_bloc.dart';",
@@ -24,7 +43,6 @@
 	"Event base": {
 		"prefix": "event",
 		"scope": "dart",
-		"description": "Create the base for a new bloc event class",
 		"body": [
 			"part of '${1/(.*)/${1:/downcase}/}_bloc.dart';",
 			"",
@@ -42,7 +60,6 @@
 	"State base": {
 		"prefix": "state",
 		"scope": "dart",
-		"description": "Create the base for a bloc state class",
 		"body": [
 			"part of '${1/(.*)/${1:/downcase}/}_bloc.dart';",
 			"",

--- a/android/fastlane/metadata/android/free/en-US/changelogs/59.txt
+++ b/android/fastlane/metadata/android/free/en-US/changelogs/59.txt
@@ -1,4 +1,8 @@
 Version 0.6.11
 2021-xx-xx
 
+· Updated home app bar
+· Added option to show home app bar at the bottom 
+  · in settings > general
 · Enabled transparent navigation bar for Android 10 and below (Thanks Steve-Mr!)
+· Minor style improvements

--- a/lib/components/common/timeline/home_timeline/bloc/home_timeline_state.dart
+++ b/lib/components/common/timeline/home_timeline/bloc/home_timeline_state.dart
@@ -21,7 +21,7 @@ extension HomeTimelineExtension on HomeTimelineState? {
       this is HomeTimelineResult &&
       (this as HomeTimelineResult).canRequestOlder;
 
-  bool get enableScroll => timelineTweets.isNotEmpty;
+  bool get hasTweets => timelineTweets.isNotEmpty;
 
   bool get enableFilter =>
       this is HomeTimelineResult || timelineFilter != TimelineFilter.empty;

--- a/lib/components/common/timeline/home_timeline/widgets/home_timeline.dart
+++ b/lib/components/common/timeline/home_timeline/widgets/home_timeline.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_feather_icons/flutter_feather_icons.dart';
 import 'package:harpy/api/api.dart';
 import 'package:harpy/components/components.dart';
-import 'package:harpy/core/core.dart';
-import 'package:harpy/misc/misc.dart';
 
 class HomeTimeline extends StatefulWidget {
   const HomeTimeline();
@@ -69,7 +66,6 @@ class _HomeTimelineState extends State<HomeTimeline> {
       child: ScrollToStart(
         controller: _controller,
         child: CustomRefreshIndicator(
-          offset: mediaQuery.padding.top - 8,
           onRefresh: () async {
             ScrollDirection.of(context)!.reset();
             bloc.add(const RefreshHomeTimeline());
@@ -81,50 +77,47 @@ class _HomeTimelineState extends State<HomeTimeline> {
               bloc.add(const RequestOlderHomeTimeline());
               await bloc.requestOlderCompleter.future;
             },
-            child: ScrollAwareFloatingActionButton(
-              floatingActionButton: FloatingActionButton(
-                onPressed: () => app<HarpyNavigator>().pushComposeScreen(),
-                child: const Icon(FeatherIcons.feather, size: 28),
-              ),
-              child: TweetList(
-                state.timelineTweets,
-                key: const PageStorageKey<String>('home_timeline'),
-                controller: _controller,
-                tweetBuilder: (tweet) => _tweetBuilder(state, tweet),
-                enableScroll: state.enableScroll,
-                endSlivers: [
-                  if (state.showInitialLoading)
-                    const TweetListLoadingSliver()
-                  else if (state.showNoTweetsFound)
-                    SliverFillLoadingError(
-                      message: const Text('no tweets found'),
-                      onRetry: () => bloc.add(
-                        const RefreshHomeTimeline(clearPrevious: true),
-                      ),
-                      onClearFilter: state.hasTimelineFilter
-                          ? () => bloc.add(const FilterHomeTimeline(
-                                timelineFilter: TimelineFilter.empty,
-                              ))
-                          : null,
-                    )
-                  else if (state.showTimelineError)
-                    SliverFillLoadingError(
-                      message: const Text('error loading tweets'),
-                      onRetry: () => bloc.add(
-                        const RefreshHomeTimeline(clearPrevious: true),
-                      ),
-                    )
-                  else if (state.showLoadingOlder)
-                    const SliverBoxLoadingIndicator()
-                  else if (state.showReachedEnd)
-                    const SliverBoxInfoMessage(
-                      secondaryMessage: Text('no more tweets available'),
+            child: TweetList(
+              state.timelineTweets,
+              key: const PageStorageKey<String>('home_timeline'),
+              controller: _controller,
+              tweetBuilder: (tweet) => _tweetBuilder(state, tweet),
+              enableScroll: state.hasTweets,
+              beginSlivers: [
+                if (state.hasTweets) const HomeTimelineTopRow(),
+              ],
+              endSlivers: [
+                if (state.showInitialLoading)
+                  const TweetListLoadingSliver()
+                else if (state.showNoTweetsFound)
+                  SliverFillLoadingError(
+                    message: const Text('no tweets found'),
+                    onRetry: () => bloc.add(
+                      const RefreshHomeTimeline(clearPrevious: true),
                     ),
-                  SliverToBoxAdapter(
-                    child: SizedBox(height: mediaQuery.padding.bottom),
+                    onClearFilter: state.hasTimelineFilter
+                        ? () => bloc.add(const FilterHomeTimeline(
+                              timelineFilter: TimelineFilter.empty,
+                            ))
+                        : null,
+                  )
+                else if (state.showTimelineError)
+                  SliverFillLoadingError(
+                    message: const Text('error loading tweets'),
+                    onRetry: () => bloc.add(
+                      const RefreshHomeTimeline(clearPrevious: true),
+                    ),
+                  )
+                else if (state.showLoadingOlder)
+                  const SliverBoxLoadingIndicator()
+                else if (state.showReachedEnd)
+                  const SliverBoxInfoMessage(
+                    secondaryMessage: Text('no more tweets available'),
                   ),
-                ],
-              ),
+                SliverToBoxAdapter(
+                  child: SizedBox(height: mediaQuery.padding.bottom),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/components/common/timeline/home_timeline/widgets/home_timeline_top_row.dart
+++ b/lib/components/common/timeline/home_timeline/widgets/home_timeline_top_row.dart
@@ -40,14 +40,14 @@ class _RefreshButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final harpyTheme = context.watch<HarpyTheme>();
+    final theme = Theme.of(context);
     final config = context.watch<ConfigCubit>().state;
     final bloc = context.watch<HomeTimelineBloc>();
 
     return HarpyButton.raised(
       padding: config.edgeInsets,
       elevation: 0,
-      backgroundColor: harpyTheme.alternateCardColor,
+      backgroundColor: theme.cardTheme.color,
       icon: const Icon(Icons.refresh),
       onTap: () => bloc.add(const RefreshHomeTimeline(clearPrevious: true)),
     );
@@ -59,13 +59,13 @@ class _ComposeButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final harpyTheme = context.watch<HarpyTheme>();
+    final theme = Theme.of(context);
     final config = context.watch<ConfigCubit>().state;
 
     return HarpyButton.raised(
       padding: config.edgeInsets,
       elevation: 0,
-      backgroundColor: harpyTheme.alternateCardColor,
+      backgroundColor: theme.cardTheme.color,
       icon: const Icon(FeatherIcons.feather),
       onTap: () => app<HarpyNavigator>().pushComposeScreen(),
     );
@@ -78,7 +78,6 @@ class _FilterButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final harpyTheme = context.watch<HarpyTheme>();
     final config = context.watch<ConfigCubit>().state;
     final bloc = context.watch<HomeTimelineBloc>();
     final state = bloc.state;
@@ -89,11 +88,9 @@ class _FilterButton extends StatelessWidget {
     return HarpyButton.raised(
       padding: config.edgeInsets,
       elevation: 0,
-      backgroundColor: hasFilter
-          ? theme.colorScheme.secondary.withOpacity(.9)
-          : harpyTheme.alternateCardColor,
+      backgroundColor: theme.cardTheme.color,
       icon: hasFilter
-          ? const Icon(Icons.filter_alt)
+          ? Icon(Icons.filter_alt, color: theme.colorScheme.primary)
           : const Icon(Icons.filter_alt_outlined),
       onTap:
           bloc.state.enableFilter ? Scaffold.of(context).openEndDrawer : null,

--- a/lib/components/common/timeline/home_timeline/widgets/home_timeline_top_row.dart
+++ b/lib/components/common/timeline/home_timeline/widgets/home_timeline_top_row.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_feather_icons/flutter_feather_icons.dart';
+import 'package:harpy/components/components.dart';
+import 'package:harpy/core/core.dart';
+import 'package:harpy/harpy_widgets/harpy_widgets.dart';
+import 'package:harpy/misc/harpy_navigator.dart';
+
+/// Built as the begin sliver for the home timeline.
+class HomeTimelineTopRow extends StatelessWidget {
+  const HomeTimelineTopRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final config = context.watch<ConfigCubit>().state;
+
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: config.edgeInsetsOnly(
+          top: true,
+          left: true,
+          right: true,
+        ),
+        child: Row(
+          children: const [
+            _RefreshButton(),
+            Spacer(),
+            _ComposeButton(),
+            defaultHorizontalSpacer,
+            _FilterButton(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RefreshButton extends StatelessWidget {
+  const _RefreshButton() : super();
+
+  @override
+  Widget build(BuildContext context) {
+    final harpyTheme = context.watch<HarpyTheme>();
+    final config = context.watch<ConfigCubit>().state;
+    final bloc = context.watch<HomeTimelineBloc>();
+
+    return HarpyButton.raised(
+      padding: config.edgeInsets,
+      elevation: 0,
+      backgroundColor: harpyTheme.alternateCardColor,
+      icon: const Icon(Icons.refresh),
+      onTap: () => bloc.add(const RefreshHomeTimeline(clearPrevious: true)),
+    );
+  }
+}
+
+class _ComposeButton extends StatelessWidget {
+  const _ComposeButton() : super();
+
+  @override
+  Widget build(BuildContext context) {
+    final harpyTheme = context.watch<HarpyTheme>();
+    final config = context.watch<ConfigCubit>().state;
+
+    return HarpyButton.raised(
+      padding: config.edgeInsets,
+      elevation: 0,
+      backgroundColor: harpyTheme.alternateCardColor,
+      icon: const Icon(FeatherIcons.feather),
+      onTap: () => app<HarpyNavigator>().pushComposeScreen(),
+    );
+  }
+}
+
+class _FilterButton extends StatelessWidget {
+  const _FilterButton() : super();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final harpyTheme = context.watch<HarpyTheme>();
+    final config = context.watch<ConfigCubit>().state;
+    final bloc = context.watch<HomeTimelineBloc>();
+    final state = bloc.state;
+
+    final hasFilter =
+        state.enableFilter && state.timelineFilter != TimelineFilter.empty;
+
+    return HarpyButton.raised(
+      padding: config.edgeInsets,
+      elevation: 0,
+      backgroundColor: hasFilter
+          ? theme.colorScheme.secondary.withOpacity(.9)
+          : harpyTheme.alternateCardColor,
+      icon: hasFilter
+          ? const Icon(Icons.filter_alt)
+          : const Icon(Icons.filter_alt_outlined),
+      onTap:
+          bloc.state.enableFilter ? Scaffold.of(context).openEndDrawer : null,
+    );
+  }
+}

--- a/lib/components/common/timeline/media_timeline/widget/media_timeline.dart
+++ b/lib/components/common/timeline/media_timeline/widget/media_timeline.dart
@@ -26,7 +26,7 @@ class MediaTimeline extends StatefulWidget {
 class _MediaTimelineState extends State<MediaTimeline> {
   bool _buildTiled = app<LayoutPreferences>().mediaTiled;
 
-  Widget _buildTopRow(Config config, HarpyTheme harpyTheme) {
+  Widget _buildTopRow(Config config, ThemeData theme) {
     return SliverToBoxAdapter(
       child: Padding(
         padding: config.edgeInsetsOnly(
@@ -40,7 +40,7 @@ class _MediaTimelineState extends State<MediaTimeline> {
             HarpyButton.raised(
               padding: config.edgeInsets,
               elevation: 0,
-              backgroundColor: harpyTheme.alternateCardColor,
+              backgroundColor: theme.cardTheme.color,
               icon: Icon(
                 _buildTiled
                     ? CupertinoIcons.square_split_1x2
@@ -94,7 +94,7 @@ class _MediaTimelineState extends State<MediaTimeline> {
   @override
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
-    final harpyTheme = context.watch<HarpyTheme>();
+    final theme = Theme.of(context);
     final config = context.watch<ConfigCubit>().state;
 
     final model = context.watch<MediaTimelineModel>();
@@ -106,7 +106,7 @@ class _MediaTimelineState extends State<MediaTimeline> {
         if (widget.showInitialLoading)
           const SliverFillLoadingIndicator()
         else if (model.hasEntries) ...[
-          _buildTopRow(config, harpyTheme),
+          _buildTopRow(config, theme),
           SliverPadding(
             padding: config.edgeInsets,
             sliver: _buildList(config, entries),

--- a/lib/components/common/timeline/media_timeline/widget/media_timeline.dart
+++ b/lib/components/common/timeline/media_timeline/widget/media_timeline.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
+import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:waterfall_flow/waterfall_flow.dart';
 
@@ -25,17 +26,34 @@ class MediaTimeline extends StatefulWidget {
 class _MediaTimelineState extends State<MediaTimeline> {
   bool _buildTiled = app<LayoutPreferences>().mediaTiled;
 
-  Widget _buildFloatingActionButton() {
-    return FloatingActionButton(
-      onPressed: () => setState(() {
-        final value = !_buildTiled;
-        _buildTiled = value;
-        app<LayoutPreferences>().mediaTiled = value;
-      }),
-      child: Icon(
-        _buildTiled
-            ? CupertinoIcons.square_split_1x2
-            : CupertinoIcons.square_split_2x2,
+  Widget _buildTopRow(Config config, HarpyTheme harpyTheme) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: config.edgeInsetsOnly(
+          top: true,
+          left: true,
+          right: true,
+        ),
+        child: Row(
+          children: [
+            const Spacer(),
+            HarpyButton.raised(
+              padding: config.edgeInsets,
+              elevation: 0,
+              backgroundColor: harpyTheme.alternateCardColor,
+              icon: Icon(
+                _buildTiled
+                    ? CupertinoIcons.square_split_1x2
+                    : CupertinoIcons.square_split_2x2,
+              ),
+              onTap: () => setState(() {
+                final value = !_buildTiled;
+                _buildTiled = value;
+                app<LayoutPreferences>().mediaTiled = value;
+              }),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -76,35 +94,32 @@ class _MediaTimelineState extends State<MediaTimeline> {
   @override
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
+    final harpyTheme = context.watch<HarpyTheme>();
     final config = context.watch<ConfigCubit>().state;
 
     final model = context.watch<MediaTimelineModel>();
     final entries = model.value;
 
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      floatingActionButton:
-          model.hasEntries ? _buildFloatingActionButton() : null,
-      body: CustomScrollView(
-        key: const PageStorageKey<String>('user_media_timeline'),
-        slivers: [
-          if (widget.showInitialLoading)
-            const SliverFillLoadingIndicator()
-          else if (model.hasEntries) ...[
-            SliverPadding(
-              padding: config.edgeInsets,
-              sliver: _buildList(config, entries),
-            ),
-            if (widget.showLoadingOlder) const SliverBoxLoadingIndicator(),
-          ] else
-            const SliverFillLoadingError(
-              message: Text('no media found'),
-            ),
-          SliverToBoxAdapter(
-            child: SizedBox(height: mediaQuery.padding.bottom),
+    return CustomScrollView(
+      key: const PageStorageKey<String>('user_media_timeline'),
+      slivers: [
+        if (widget.showInitialLoading)
+          const SliverFillLoadingIndicator()
+        else if (model.hasEntries) ...[
+          _buildTopRow(config, harpyTheme),
+          SliverPadding(
+            padding: config.edgeInsets,
+            sliver: _buildList(config, entries),
           ),
-        ],
-      ),
+          if (widget.showLoadingOlder) const SliverBoxLoadingIndicator(),
+        ] else
+          const SliverFillLoadingError(
+            message: Text('no media found'),
+          ),
+        SliverToBoxAdapter(
+          child: SizedBox(height: mediaQuery.padding.bottom),
+        ),
+      ],
     );
   }
 }

--- a/lib/components/common/trends/widgets/trends_card.dart
+++ b/lib/components/common/trends/widgets/trends_card.dart
@@ -38,8 +38,10 @@ class TrendsCard extends StatelessWidget {
             ),
           ),
           defaultHorizontalSpacer,
-          HarpyButton.flat(
+          HarpyButton.raised(
             padding: config.edgeInsets,
+            elevation: 0,
+            backgroundColor: theme.cardTheme.color,
             icon: const Icon(CupertinoIcons.refresh),
             onTap: state.isLoading
                 ? null

--- a/lib/components/components.dart
+++ b/lib/components/components.dart
@@ -15,6 +15,7 @@ export 'common/timeline/filter/model/timeline_filter_model.dart';
 export 'common/timeline/filter/widgets/timeline_filter_drawer.dart';
 export 'common/timeline/home_timeline/bloc/home_timeline_bloc.dart';
 export 'common/timeline/home_timeline/widgets/home_timeline.dart';
+export 'common/timeline/home_timeline/widgets/home_timeline_top_row.dart';
 export 'common/timeline/home_timeline/widgets/home_timeline_tweet_card.dart';
 export 'common/timeline/likes_timeline/bloc/likes_timeline_bloc.dart';
 export 'common/timeline/likes_timeline/widgets/likes_timeline.dart';

--- a/lib/components/screens/home/home_tab_customization/widgets/add_list_home_tab_card.dart
+++ b/lib/components/screens/home/home_tab_customization/widgets/add_list_home_tab_card.dart
@@ -22,14 +22,13 @@ class AddListHomeTabCard extends StatelessWidget {
     final theme = Theme.of(context);
     final model = context.watch<HomeTabModel>();
 
+    final iconSize = theme.iconTheme.size!;
+
     final Widget icon = Padding(
       padding: EdgeInsets.all(HarpyTab.tabPadding(context)),
       child: proDisabled
-          ? const FlareIcon.shiningStar(size: HarpyTab.tabIconSize)
-          : const Icon(
-              CupertinoIcons.add,
-              size: HarpyTab.tabIconSize,
-            ),
+          ? FlareIcon.shiningStar(size: iconSize)
+          : Icon(CupertinoIcons.add, size: iconSize),
     );
 
     return Container(

--- a/lib/components/screens/home/home_tab_customization/widgets/add_list_home_tab_card.dart
+++ b/lib/components/screens/home/home_tab_customization/widgets/add_list_home_tab_card.dart
@@ -23,7 +23,7 @@ class AddListHomeTabCard extends StatelessWidget {
     final model = context.watch<HomeTabModel>();
 
     final Widget icon = Padding(
-      padding: const EdgeInsets.all(HarpyTab.tabPadding),
+      padding: EdgeInsets.all(HarpyTab.tabPadding(context)),
       child: proDisabled
           ? const FlareIcon.shiningStar(size: HarpyTab.tabIconSize)
           : const Icon(

--- a/lib/components/screens/home/home_tab_customization/widgets/home_tab_entry_icon.dart
+++ b/lib/components/screens/home/home_tab_customization/widgets/home_tab_entry_icon.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 
 class HomeTabEntryIcon extends StatelessWidget {
   const HomeTabEntryIcon(
     this.iconName, {
-    this.size = HarpyTab.tabIconSize,
+    this.size,
   });
 
   /// The name that matches the icon data in [iconNameMap].
@@ -14,7 +13,7 @@ class HomeTabEntryIcon extends StatelessWidget {
   /// instead.
   final String? iconName;
 
-  final double size;
+  final double? size;
 
   /// Maps the name of an icon to its [IconData].
   static const Map<String, IconData> iconNameMap = <String, IconData>{
@@ -75,6 +74,8 @@ class HomeTabEntryIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final size = this.size ?? Theme.of(context).iconTheme.size!;
+
     if (iconName?.length == 1) {
       return Container(
         width: size,

--- a/lib/components/screens/home/home_tab_customization/widgets/home_tab_reorder_card.dart
+++ b/lib/components/screens/home/home_tab_customization/widgets/home_tab_reorder_card.dart
@@ -61,7 +61,6 @@ class _HomeTabReorderCardState extends State<HomeTabReorderCard> {
       padding: EdgeInsets.all(tabPadding).copyWith(right: tabPadding / 2),
       icon: Icon(
         _entry.visible! ? CupertinoIcons.eye : CupertinoIcons.eye_slash,
-        size: HarpyTab.tabIconSize,
       ),
       // prevent hiding the last entry
       onTap: !widget.model.canHideMoreEntries && _entry.visible!
@@ -76,10 +75,7 @@ class _HomeTabReorderCardState extends State<HomeTabReorderCard> {
   Widget _buildRemoveEntryIcon(double tabPadding) {
     return HarpyButton.flat(
       padding: EdgeInsets.all(tabPadding).copyWith(right: tabPadding / 2),
-      icon: const Icon(
-        CupertinoIcons.xmark,
-        size: HarpyTab.tabIconSize,
-      ),
+      icon: const Icon(CupertinoIcons.xmark),
       onTap: () {
         HapticFeedback.lightImpact();
         widget.model.remove(widget.index);
@@ -145,10 +141,7 @@ class _HomeTabReorderCardState extends State<HomeTabReorderCard> {
                   left: tabPadding / 2,
                 ),
                 color: Colors.transparent,
-                child: const Icon(
-                  CupertinoIcons.bars,
-                  size: HarpyTab.tabIconSize,
-                ),
+                child: const Icon(CupertinoIcons.bars),
               ),
             ),
           ],

--- a/lib/components/screens/home/home_tab_customization/widgets/home_tab_reorder_card.dart
+++ b/lib/components/screens/home/home_tab_customization/widgets/home_tab_reorder_card.dart
@@ -56,10 +56,9 @@ class _HomeTabReorderCardState extends State<HomeTabReorderCard> {
     );
   }
 
-  Widget _buildToggleVisibilityIcon() {
+  Widget _buildToggleVisibilityIcon(double tabPadding) {
     return HarpyButton.flat(
-      padding: const EdgeInsets.all(HarpyTab.tabPadding)
-          .copyWith(right: HarpyTab.tabPadding / 2),
+      padding: EdgeInsets.all(tabPadding).copyWith(right: tabPadding / 2),
       icon: Icon(
         _entry.visible! ? CupertinoIcons.eye : CupertinoIcons.eye_slash,
         size: HarpyTab.tabIconSize,
@@ -74,10 +73,9 @@ class _HomeTabReorderCardState extends State<HomeTabReorderCard> {
     );
   }
 
-  Widget _buildRemoveEntryIcon() {
+  Widget _buildRemoveEntryIcon(double tabPadding) {
     return HarpyButton.flat(
-      padding: const EdgeInsets.all(HarpyTab.tabPadding)
-          .copyWith(right: HarpyTab.tabPadding / 2),
+      padding: EdgeInsets.all(tabPadding).copyWith(right: tabPadding / 2),
       icon: const Icon(
         CupertinoIcons.xmark,
         size: HarpyTab.tabIconSize,
@@ -94,6 +92,8 @@ class _HomeTabReorderCardState extends State<HomeTabReorderCard> {
     final theme = Theme.of(context);
     final config = context.watch<ConfigCubit>().state;
 
+    final tabPadding = HarpyTab.tabPadding(context);
+
     return AnimatedOpacity(
       duration: kShortAnimationDuration,
       opacity: _entry.visible! ? 1 : .6,
@@ -102,9 +102,9 @@ class _HomeTabReorderCardState extends State<HomeTabReorderCard> {
         child: Row(
           children: [
             Padding(
-              padding: const EdgeInsets.all(HarpyTab.tabPadding / 2),
+              padding: EdgeInsets.all(tabPadding / 2),
               child: HarpyButton.raised(
-                padding: const EdgeInsets.all(HarpyTab.tabPadding / 2),
+                padding: EdgeInsets.all(tabPadding / 2),
                 icon: HomeTabEntryIcon(_entry.icon),
                 onTap: () async {
                   widget.model.changeIcon(
@@ -128,21 +128,22 @@ class _HomeTabReorderCardState extends State<HomeTabReorderCard> {
             Flexible(
               child: Padding(
                 padding: EdgeInsets.symmetric(
-                  vertical: HarpyTab.tabPadding,
+                  vertical: tabPadding,
                   horizontal: config.smallPaddingValue,
                 ),
                 child: _buildTextField(theme),
               ),
             ),
             if (_entry.removable)
-              _buildRemoveEntryIcon()
+              _buildRemoveEntryIcon(tabPadding)
             else
-              _buildToggleVisibilityIcon(),
+              _buildToggleVisibilityIcon(tabPadding),
             ReorderableDragStartListener(
               index: widget.index,
               child: Container(
-                padding: const EdgeInsets.all(HarpyTab.tabPadding)
-                    .copyWith(left: HarpyTab.tabPadding / 2),
+                padding: EdgeInsets.all(tabPadding).copyWith(
+                  left: tabPadding / 2,
+                ),
                 color: Colors.transparent,
                 child: const Icon(
                   CupertinoIcons.bars,

--- a/lib/components/screens/home/home_tab_view.dart
+++ b/lib/components/screens/home/home_tab_view.dart
@@ -33,6 +33,7 @@ class HomeTabView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
     final config = context.watch<ConfigCubit>().state;
     final model = context.watch<HomeTabModel>();
 
@@ -47,6 +48,10 @@ class HomeTabView extends StatelessWidget {
               if (!config.bottomAppBar)
                 SliverToBoxAdapter(
                   child: SizedBox(height: HomeAppBar.height(context)),
+                )
+              else
+                SliverToBoxAdapter(
+                  child: SizedBox(height: mediaQuery.padding.top),
                 ),
             ],
             body: TabBarView(

--- a/lib/components/screens/home/home_tab_view.dart
+++ b/lib/components/screens/home/home_tab_view.dart
@@ -33,7 +33,7 @@ class HomeTabView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mediaQuery = MediaQuery.of(context);
+    final config = context.watch<ConfigCubit>().state;
     final model = context.watch<HomeTabModel>();
 
     return DefaultTabController(
@@ -44,11 +44,10 @@ class HomeTabView extends StatelessWidget {
             headerSliverBuilder: (_, __) => [
               // padding for the home app bar that is built above the nested
               // scroll view
-              SliverToBoxAdapter(
-                child: SizedBox(
-                  height: HomeAppBar.height(mediaQuery.padding.top - 8),
+              if (!config.bottomAppBar)
+                SliverToBoxAdapter(
+                  child: SizedBox(height: HomeAppBar.height(context)),
                 ),
-              ),
             ],
             body: TabBarView(
               children: [

--- a/lib/components/screens/home/widgets/customize_home_tab.dart
+++ b/lib/components/screens/home/widgets/customize_home_tab.dart
@@ -28,7 +28,7 @@ class CustomizeHomeTab extends StatelessWidget {
     if (Harpy.isFree) {
       return Bubbled(
         bubble: const FlareIcon.shiningStar(),
-        bubbleOffset: const Offset(4, -4),
+        bubbleOffset: const Offset(2, -2),
         child: child,
       );
     } else {

--- a/lib/components/screens/home/widgets/customize_home_tab.dart
+++ b/lib/components/screens/home/widgets/customize_home_tab.dart
@@ -9,21 +9,18 @@ import 'package:harpy/misc/misc.dart';
 import 'package:provider/provider.dart';
 
 class CustomizeHomeTab extends StatelessWidget {
-  const CustomizeHomeTab({
-    this.cardColor,
-  });
-
-  final Color? cardColor;
+  const CustomizeHomeTab();
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final Widget child = HarpyButton.flat(
-      padding: const EdgeInsets.all(HarpyTab.tabPadding - 2),
+    final Widget child = HarpyButton.raised(
+      elevation: 0,
+      backgroundColor: theme.colorScheme.secondary.withOpacity(.9),
+      padding: EdgeInsets.all(HarpyTab.tabPadding(context)),
+      iconSize: HarpyTab.tabIconSize,
       icon: const Icon(FeatherIcons.settings),
-      iconSize: HarpyTab.tabIconSize + 2,
-      foregroundColor: theme.iconTheme.color!.withOpacity(.8),
       onTap: () => app<HarpyNavigator>().pushHomeTabCustomizationScreen(
         model: context.read<HomeTabModel>(),
       ),

--- a/lib/components/screens/home/widgets/customize_home_tab.dart
+++ b/lib/components/screens/home/widgets/customize_home_tab.dart
@@ -19,7 +19,6 @@ class CustomizeHomeTab extends StatelessWidget {
       elevation: 0,
       backgroundColor: theme.colorScheme.secondary.withOpacity(.9),
       padding: EdgeInsets.all(HarpyTab.tabPadding(context)),
-      iconSize: HarpyTab.tabIconSize,
       icon: const Icon(FeatherIcons.settings),
       onTap: () => app<HarpyNavigator>().pushHomeTabCustomizationScreen(
         model: context.read<HomeTabModel>(),

--- a/lib/components/screens/home/widgets/home_app_bar.dart
+++ b/lib/components/screens/home/widgets/home_app_bar.dart
@@ -75,25 +75,31 @@ class HomeAppBar extends StatelessWidget {
     // scroll view in the home tab view, we use an animated shifted position
     // widget and animate the app bar out of the view based on the scroll
     // position to manually hide / show the app bar
-    return AnimatedShiftedPosition(
-      shift: scrollDirection.direction == VerticalDirection.down
-          ? const Offset(0, -1)
-          : Offset.zero,
-      child: Stack(
-        children: [
-          HomeTabBar(
-            padding: EdgeInsets.only(
-              top: topPadding,
-              bottom: bottomPadding,
-              left: HarpyTab.height(context) + config.paddingValue * 2,
-              right: config.paddingValue,
+    return Align(
+      alignment:
+          config.bottomAppBar ? Alignment.bottomCenter : Alignment.topCenter,
+      child: AnimatedShiftedPosition(
+        shift: scrollDirection.direction == VerticalDirection.down
+            ? config.bottomAppBar
+                ? const Offset(0, 1)
+                : const Offset(0, -1)
+            : Offset.zero,
+        child: Stack(
+          children: [
+            HomeTabBar(
+              padding: EdgeInsets.only(
+                top: topPadding,
+                bottom: bottomPadding,
+                left: HarpyTab.height(context) + config.paddingValue * 2,
+                right: config.paddingValue,
+              ),
             ),
-          ),
-          Padding(
-            padding: EdgeInsets.only(top: topPadding, bottom: bottomPadding),
-            child: const _DrawerButton(),
-          ),
-        ],
+            Padding(
+              padding: EdgeInsets.only(top: topPadding, bottom: bottomPadding),
+              child: const _DrawerButton(),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/components/screens/home/widgets/home_app_bar.dart
+++ b/lib/components/screens/home/widgets/home_app_bar.dart
@@ -1,60 +1,75 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_feather_icons/flutter_feather_icons.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 import 'package:provider/provider.dart';
 
+// todo: add actions to home timeline
+
+//   List<Widget> _buildActions(
+//     BuildContext context,
+//     ThemeData theme,
+//     TimelineFilterModel model,
+//     HomeTimelineBloc bloc,
+//   ) {
+//     return [
+//       HarpyButton.flat(
+//         padding: const EdgeInsets.all(16),
+//         icon: bloc.state.enableFilter &&
+//                 bloc.state.timelineFilter != TimelineFilter.empty
+//             ? Icon(Icons.filter_alt, color: theme.colorScheme.secondary)
+//             : const Icon(Icons.filter_alt_outlined),
+//         onTap:
+//             bloc.state.enableFilter ? Scaffold.of(context).openEndDrawer : null,
+//       ),
+//       CustomPopupMenuButton<int>(
+//         icon: const Icon(Icons.more_vert),
+//         onSelected: (selection) {
+//           if (selection == 0) {
+//             ScrollDirection.of(context)!.reset();
+
+//             bloc.add(const RefreshHomeTimeline(clearPrevious: true));
+//           }
+//         },
+//         itemBuilder: (context) {
+//           return <PopupMenuEntry<int>>[
+//             const HarpyPopupMenuItem<int>(
+//               value: 0,
+//               text: Text('refresh'),
+//             ),
+//           ];
+//         },
+//       ),
+//     ];
+//   }
+
+// todo: add support for building home app bar at the bottom
+
 class HomeAppBar extends StatelessWidget {
   const HomeAppBar();
 
-  static double height(double topPadding) =>
-      topPadding + kToolbarHeight + HomeTabBar.height;
+  static double height(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final config = context.read<ConfigCubit>().state;
 
-  List<Widget> _buildActions(
-    BuildContext context,
-    ThemeData theme,
-    TimelineFilterModel model,
-    HomeTimelineBloc bloc,
-  ) {
-    return [
-      HarpyButton.flat(
-        padding: const EdgeInsets.all(16),
-        icon: bloc.state.enableFilter &&
-                bloc.state.timelineFilter != TimelineFilter.empty
-            ? Icon(Icons.filter_alt, color: theme.colorScheme.secondary)
-            : const Icon(Icons.filter_alt_outlined),
-        onTap:
-            bloc.state.enableFilter ? Scaffold.of(context).openEndDrawer : null,
-      ),
-      CustomPopupMenuButton<int>(
-        icon: const Icon(Icons.more_vert),
-        onSelected: (selection) {
-          if (selection == 0) {
-            ScrollDirection.of(context)!.reset();
+    final systemPadding = config.bottomAppBar
+        ? mediaQuery.padding.bottom
+        : mediaQuery.padding.top;
 
-            bloc.add(const RefreshHomeTimeline(clearPrevious: true));
-          }
-        },
-        itemBuilder: (context) {
-          return <PopupMenuEntry<int>>[
-            const HarpyPopupMenuItem<int>(
-              value: 0,
-              text: Text('refresh'),
-            ),
-          ];
-        },
-      ),
-    ];
+    return HarpyTab.height(context) + systemPadding + 4;
   }
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final mediaQuery = MediaQuery.of(context);
     final scrollDirection = ScrollDirection.of(context)!;
+    final config = context.watch<ConfigCubit>().state;
 
-    final model = context.watch<TimelineFilterModel>();
-    final bloc = context.watch<HomeTimelineBloc>();
+    final topPadding = config.bottomAppBar ? 0.0 : mediaQuery.padding.top + 4;
+    final bottomPadding =
+        config.bottomAppBar ? mediaQuery.padding.bottom + 4 : 0.0;
 
     // since the sliver app bar does not work as intended with the nested
     // scroll view in the home tab view, we use an animated shifted position
@@ -64,18 +79,45 @@ class HomeAppBar extends StatelessWidget {
       shift: scrollDirection.direction == VerticalDirection.down
           ? const Offset(0, -1)
           : Offset.zero,
-      child: CustomScrollView(
-        shrinkWrap: true,
-        slivers: [
-          HarpySliverAppBar(
-            title: 'Harpy',
-            showIcon: true,
-            floating: true,
-            snap: true,
-            actions: _buildActions(context, theme, model, bloc),
-            bottom: const HomeTabBar(),
+      child: Stack(
+        children: [
+          HomeTabBar(
+            padding: EdgeInsets.only(
+              top: topPadding,
+              bottom: bottomPadding,
+              left: HarpyTab.height(context) + config.paddingValue * 2,
+              right: config.paddingValue,
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.only(top: topPadding, bottom: bottomPadding),
+            child: const _DrawerButton(),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _DrawerButton extends StatelessWidget {
+  const _DrawerButton();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final config = context.watch<ConfigCubit>().state;
+
+    return Padding(
+      padding: config.edgeInsetsOnly(left: true),
+      child: HarpyButton.raised(
+        backgroundColor: theme.colorScheme.primary.withOpacity(.9),
+        padding: EdgeInsets.all(HarpyTab.tabPadding(context)),
+        iconSize: HarpyTab.tabIconSize,
+        icon: const RotatedBox(
+          quarterTurns: 1,
+          child: Icon(FeatherIcons.barChart2),
+        ),
+        onTap: Scaffold.of(context).openDrawer,
       ),
     );
   }

--- a/lib/components/screens/home/widgets/home_app_bar.dart
+++ b/lib/components/screens/home/widgets/home_app_bar.dart
@@ -6,47 +6,6 @@ import 'package:harpy/components/components.dart';
 import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 import 'package:provider/provider.dart';
 
-// todo: add actions to home timeline
-
-//   List<Widget> _buildActions(
-//     BuildContext context,
-//     ThemeData theme,
-//     TimelineFilterModel model,
-//     HomeTimelineBloc bloc,
-//   ) {
-//     return [
-//       HarpyButton.flat(
-//         padding: const EdgeInsets.all(16),
-//         icon: bloc.state.enableFilter &&
-//                 bloc.state.timelineFilter != TimelineFilter.empty
-//             ? Icon(Icons.filter_alt, color: theme.colorScheme.secondary)
-//             : const Icon(Icons.filter_alt_outlined),
-//         onTap:
-//             bloc.state.enableFilter ? Scaffold.of(context).openEndDrawer : null,
-//       ),
-//       CustomPopupMenuButton<int>(
-//         icon: const Icon(Icons.more_vert),
-//         onSelected: (selection) {
-//           if (selection == 0) {
-//             ScrollDirection.of(context)!.reset();
-
-//             bloc.add(const RefreshHomeTimeline(clearPrevious: true));
-//           }
-//         },
-//         itemBuilder: (context) {
-//           return <PopupMenuEntry<int>>[
-//             const HarpyPopupMenuItem<int>(
-//               value: 0,
-//               text: Text('refresh'),
-//             ),
-//           ];
-//         },
-//       ),
-//     ];
-//   }
-
-// todo: add support for building home app bar at the bottom
-
 class HomeAppBar extends StatelessWidget {
   const HomeAppBar();
 
@@ -86,6 +45,7 @@ class HomeAppBar extends StatelessWidget {
             : Offset.zero,
         child: Stack(
           children: [
+            const SizedBox(width: double.infinity),
             HomeTabBar(
               padding: EdgeInsets.only(
                 top: topPadding,
@@ -118,7 +78,6 @@ class _DrawerButton extends StatelessWidget {
       child: HarpyButton.raised(
         backgroundColor: theme.colorScheme.primary.withOpacity(.9),
         padding: EdgeInsets.all(HarpyTab.tabPadding(context)),
-        iconSize: HarpyTab.tabIconSize,
         icon: const RotatedBox(
           quarterTurns: 1,
           child: Icon(FeatherIcons.barChart2),

--- a/lib/components/screens/home/widgets/home_drawer.dart
+++ b/lib/components/screens/home/widgets/home_drawer.dart
@@ -47,6 +47,16 @@ class HomeDrawer extends StatelessWidget {
                 },
               ),
 
+              // compose
+              HarpyListTile(
+                leading: const Icon(FeatherIcons.feather),
+                title: const Text('compose tweet'),
+                onTap: () async {
+                  await app<HarpyNavigator>().maybePop();
+                  app<HarpyNavigator>().pushComposeScreen();
+                },
+              ),
+
               const Divider(),
 
               // settings

--- a/lib/components/screens/home/widgets/home_tab_bar.dart
+++ b/lib/components/screens/home/widgets/home_tab_bar.dart
@@ -5,19 +5,17 @@ import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 import 'package:provider/provider.dart';
 
 /// Builds the tab bar with the tabs for the home screen.
-class HomeTabBar extends StatelessWidget with PreferredSizeWidget {
-  const HomeTabBar();
+class HomeTabBar extends StatelessWidget {
+  const HomeTabBar({
+    required this.padding,
+  });
 
-  static const double height = HarpyTab.height + 8;
-
-  @override
-  Size get preferredSize => const Size(double.infinity, height);
+  final EdgeInsets padding;
 
   Widget _mapEntryTabs(HomeTabEntry entry, Color cardColor) {
     if (entry.isDefaultType && entry.id == 'mentions') {
       return MentionsTab(
         entry: entry,
-        cardColor: cardColor,
       );
     } else {
       return HarpyTab(
@@ -35,18 +33,15 @@ class HomeTabBar extends StatelessWidget with PreferredSizeWidget {
 
     final cardColor = harpyTheme.alternateCardColor;
 
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.only(bottom: 8),
-      child: HarpyTabBar(
-        tabs: [
-          for (HomeTabEntry entry in model.visibleEntries)
-            _mapEntryTabs(entry, cardColor),
-        ],
-        endWidgets: [
-          CustomizeHomeTab(cardColor: cardColor),
-        ],
-      ),
+    return HarpyTabBar(
+      padding: padding,
+      tabs: [
+        for (HomeTabEntry entry in model.visibleEntries)
+          _mapEntryTabs(entry, cardColor),
+      ],
+      endWidgets: const [
+        CustomizeHomeTab(),
+      ],
     );
   }
 }

--- a/lib/components/screens/home/widgets/mentions_tab.dart
+++ b/lib/components/screens/home/widgets/mentions_tab.dart
@@ -27,7 +27,6 @@ class MentionsTab extends StatelessWidget {
     if (state.hasNewMentions) {
       return Bubbled(
         bubble: const Bubble(),
-        bubbleOffset: const Offset(2, -2),
         child: child,
       );
     } else {

--- a/lib/components/screens/home/widgets/mentions_tab.dart
+++ b/lib/components/screens/home/widgets/mentions_tab.dart
@@ -7,21 +7,21 @@ import 'package:provider/provider.dart';
 class MentionsTab extends StatelessWidget {
   const MentionsTab({
     required this.entry,
-    this.cardColor,
   });
 
   final HomeTabEntry entry;
-  final Color? cardColor;
 
   @override
   Widget build(BuildContext context) {
+    final harpyTheme = context.watch<HarpyTheme>();
+
     final bloc = context.watch<MentionsTimelineBloc>();
     final state = bloc.state;
 
     final Widget child = HarpyTab(
       icon: HomeTabEntryIcon(entry.icon),
       text: entry.hasName ? Text(entry.name!) : null,
-      cardColor: cardColor,
+      cardColor: harpyTheme.alternateCardColor,
     );
 
     if (state.hasNewMentions) {

--- a/lib/components/settings/config/cubit/config.dart
+++ b/lib/components/settings/config/cubit/config.dart
@@ -5,29 +5,35 @@ class Config extends Equatable {
   const Config({
     required this.fontSizeDelta,
     required this.compactMode,
+    required this.bottomAppBar,
   });
 
   final double fontSizeDelta;
   final bool compactMode;
+  final bool bottomAppBar;
 
   static const defaultConfig = Config(
     fontSizeDelta: 0,
     compactMode: false,
+    bottomAppBar: false,
   );
 
   @override
   List<Object?> get props => [
         fontSizeDelta,
         compactMode,
+        bottomAppBar,
       ];
 
   Config copyWith({
     double? fontSizeDelta,
     bool? compactMode,
+    bool? bottomAppBar,
   }) {
     return Config(
       fontSizeDelta: fontSizeDelta ?? this.fontSizeDelta,
       compactMode: compactMode ?? this.compactMode,
+      bottomAppBar: bottomAppBar ?? this.bottomAppBar,
     );
   }
 }

--- a/lib/components/settings/config/cubit/config.dart
+++ b/lib/components/settings/config/cubit/config.dart
@@ -39,7 +39,7 @@ class Config extends Equatable {
 }
 
 extension ConfigStateExtension on Config {
-  double get paddingValue => compactMode ? 10 : 16;
+  double get paddingValue => compactMode ? 12 : 16;
   double get smallPaddingValue => paddingValue / 2;
 
   EdgeInsets get edgeInsets => EdgeInsets.all(paddingValue);

--- a/lib/components/settings/config/cubit/config_cubit.dart
+++ b/lib/components/settings/config/cubit/config_cubit.dart
@@ -29,6 +29,7 @@ class ConfigCubit extends Cubit<Config> {
   void resetToDefault() {
     app<HarpyPreferences>().setInt('fontSizeDeltaId', 0);
     app<HarpyPreferences>().setBool('compactMode', false);
+    app<HarpyPreferences>().setBool('bottomAppBar', false);
 
     emit(Config.defaultConfig);
   }
@@ -54,5 +55,11 @@ class ConfigCubit extends Cubit<Config> {
         fontSizeDelta: _fontSizeDeltaIdMap[fontSizeDeltaId] ?? 0,
       ),
     );
+  }
+
+  void updateBottomAppBar(bool value) {
+    app<HarpyPreferences>().setBool('bottomAppBar', value);
+
+    emit(state.copyWith(bottomAppBar: value));
   }
 }

--- a/lib/components/settings/general/general_settings_screen.dart
+++ b/lib/components/settings/general/general_settings_screen.dart
@@ -1,7 +1,9 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
+import 'package:provider/provider.dart';
 
 class GeneralSettingsScreen extends StatefulWidget {
   const GeneralSettingsScreen();
@@ -13,43 +15,51 @@ class GeneralSettingsScreen extends StatefulWidget {
 }
 
 class _GeneralSettingsScreenState extends State<GeneralSettingsScreen> {
-  final ChangelogPreferences? changelogPreferences =
-      app<ChangelogPreferences>();
-  final GeneralPreferences? generalPreferences = app<GeneralPreferences>();
-
-  List<Widget> get _settings {
-    return [
-      HarpySwitchTile(
-        leading: const Icon(Icons.update),
-        title: const Text('show changelog dialog'),
-        subtitle: const Text('when the app has been updated'),
-        value: changelogPreferences!.showChangelogDialog,
-        onChanged: (value) {
-          HapticFeedback.lightImpact();
-          setState(() => changelogPreferences!.showChangelogDialog = value);
-        },
-      ),
-      HarpySwitchTile(
-        leading: const Icon(Icons.speed),
-        title: const Text('performance mode'),
-        subtitle: const Text('reduces animations and effects'),
-        value: generalPreferences!.performanceMode,
-        onChanged: (value) {
-          HapticFeedback.lightImpact();
-          setState(() => generalPreferences!.performanceMode = value);
-        },
-      ),
-    ];
-  }
-
   @override
   Widget build(BuildContext context) {
+    final changelogPreferences = app<ChangelogPreferences>();
+    final generalPreferences = app<GeneralPreferences>();
+
+    final configCubit = context.watch<ConfigCubit>();
+    final config = configCubit.state;
+
     return HarpyScaffold(
       title: 'general',
       buildSafeArea: true,
       body: ListView(
         padding: EdgeInsets.zero,
-        children: _settings,
+        children: [
+          HarpySwitchTile(
+            leading: const Icon(Icons.update),
+            title: const Text('show changelog dialog'),
+            subtitle: const Text('when the app has been updated'),
+            value: changelogPreferences.showChangelogDialog,
+            onChanged: (value) {
+              HapticFeedback.lightImpact();
+              setState(() => changelogPreferences.showChangelogDialog = value);
+            },
+          ),
+          HarpySwitchTile(
+            leading: const Icon(Icons.speed),
+            title: const Text('performance mode'),
+            subtitle: const Text('reduces animations and effects'),
+            value: generalPreferences.performanceMode,
+            onChanged: (value) {
+              HapticFeedback.lightImpact();
+              setState(() => generalPreferences.performanceMode = value);
+            },
+          ),
+          HarpySwitchTile(
+            leading: const Icon(CupertinoIcons.rectangle_dock),
+            title: const Text('bottom app bar'),
+            subtitle: const Text('position the home app bar at the bottom'),
+            value: config.bottomAppBar,
+            onChanged: (value) {
+              HapticFeedback.lightImpact();
+              configCubit.updateBottomAppBar(value);
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/components/widgets/list/scroll_to_start.dart
+++ b/lib/components/widgets/list/scroll_to_start.dart
@@ -106,6 +106,10 @@ class _ScrollToStartState extends State<ScrollToStart> {
 
     final show = _show(mediaQuery, scrollDirection);
 
+    final padding = config.bottomAppBar
+        ? HomeAppBar.height(context) + config.paddingValue
+        : config.paddingValue + mediaQuery.padding.bottom;
+
     return Stack(
       children: [
         widget.child,
@@ -118,14 +122,9 @@ class _ScrollToStartState extends State<ScrollToStart> {
             child: AnimatedShiftedPosition(
               shift: show ? Offset.zero : const Offset(0, 1),
               child: Padding(
-                padding: EdgeInsets.only(
-                  bottom: config.paddingValue + mediaQuery.padding.bottom,
-                ),
+                padding: EdgeInsets.only(bottom: padding),
                 child: HarpyButton.raised(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 18,
-                    vertical: 12,
-                  ),
+                  padding: config.edgeInsets,
                   icon: Icon(
                     CupertinoIcons.arrow_up,
                     color: harpyTheme.foregroundColor,

--- a/lib/components/widgets/list/scroll_to_start.dart
+++ b/lib/components/widgets/list/scroll_to_start.dart
@@ -99,6 +99,7 @@ class _ScrollToStartState extends State<ScrollToStart> {
 
   @override
   Widget build(BuildContext context) {
+    final route = ModalRoute.of(context)?.settings.name;
     final mediaQuery = MediaQuery.of(context);
     final scrollDirection = ScrollDirection.of(context);
     final harpyTheme = context.watch<HarpyTheme>();
@@ -106,7 +107,7 @@ class _ScrollToStartState extends State<ScrollToStart> {
 
     final show = _show(mediaQuery, scrollDirection);
 
-    final padding = config.bottomAppBar
+    final padding = config.bottomAppBar && route == HomeScreen.route
         ? HomeAppBar.height(context) + config.paddingValue
         : config.paddingValue + mediaQuery.padding.bottom;
 

--- a/lib/harpy_widgets/buttons/harpy_button.dart
+++ b/lib/harpy_widgets/buttons/harpy_button.dart
@@ -113,7 +113,7 @@ class HarpyButton extends StatelessWidget {
 
   /// The size of the [icon].
   ///
-  /// Defaults to the current icon theme's size (22).
+  /// Defaults to the current icon theme's size.
   final double? iconSize;
 
   /// The callback when the button is tapped.
@@ -227,7 +227,7 @@ class HarpyButton extends StatelessWidget {
     return _HarpyButtonBase(
       onTap: onTap,
       child: AnimatedTheme(
-        data: ThemeData(
+        data: theme.copyWith(
           // material background color
           canvasColor: bgColor,
 
@@ -237,7 +237,7 @@ class HarpyButton extends StatelessWidget {
           ),
 
           // icon color
-          iconTheme: IconThemeData(color: fgColor, size: iconSize),
+          iconTheme: theme.iconTheme.copyWith(color: fgColor, size: iconSize),
         ),
         child: Material(
           elevation: elevation,

--- a/lib/harpy_widgets/buttons/harpy_button.dart
+++ b/lib/harpy_widgets/buttons/harpy_button.dart
@@ -189,7 +189,13 @@ class HarpyButton extends StatelessWidget {
     } else {
       // black or white depending on the background color
 
-      return ThemeData.estimateBrightnessForColor(backgroundColor!) ==
+      final colorOnBackground = Color.lerp(
+        theme.backgroundColor,
+        backgroundColor,
+        backgroundColor!.opacity,
+      )!;
+
+      return ThemeData.estimateBrightnessForColor(colorOnBackground) ==
               Brightness.light
           ? Colors.black
           : Colors.white;

--- a/lib/harpy_widgets/harpy_tab/harpy_tab.dart
+++ b/lib/harpy_widgets/harpy_tab/harpy_tab.dart
@@ -17,15 +17,13 @@ class HarpyTab extends StatefulWidget {
   final Color? cardColor;
 
   static double height(BuildContext context) {
-    return tabPadding(context) * 2 + tabIconSize;
+    final iconSize = Theme.of(context).iconTheme.size!;
+
+    return tabPadding(context) * 2 + iconSize;
   }
 
-  static const double tabIconSize = 20;
-
   static double tabPadding(BuildContext context) {
-    final config = context.read<ConfigCubit>().state;
-
-    return config.compactMode ? 12 : 16;
+    return context.read<ConfigCubit>().state.paddingValue;
   }
 
   @override
@@ -122,14 +120,13 @@ class _HarpyTabState extends State<HarpyTab>
             child: IconTheme(
               data: iconTheme.copyWith(
                 color: _colorAnimation.value,
-                size: HarpyTab.tabIconSize,
               ),
               child: DefaultTextStyle(
                 style: theme.textTheme.subtitle1!.copyWith(
                   color: _colorAnimation.value,
                 ),
                 child: SizedBox(
-                  height: HarpyTab.tabIconSize,
+                  height: iconTheme.size,
                   child: Row(
                     children: [
                       widget.icon,

--- a/lib/harpy_widgets/harpy_tab/harpy_tab.dart
+++ b/lib/harpy_widgets/harpy_tab/harpy_tab.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/harpy_widgets/harpy_widgets.dart';
+import 'package:provider/provider.dart';
 
 /// A tab for a [HarpyTabBar].
 class HarpyTab extends StatefulWidget {
@@ -15,11 +16,17 @@ class HarpyTab extends StatefulWidget {
 
   final Color? cardColor;
 
-  /// The height of a tab.
-  static const double height = tabPadding * 2 + tabIconSize;
+  static double height(BuildContext context) {
+    return tabPadding(context) * 2 + tabIconSize;
+  }
 
-  static const double tabPadding = 16;
   static const double tabIconSize = 20;
+
+  static double tabPadding(BuildContext context) {
+    final config = context.read<ConfigCubit>().state;
+
+    return config.compactMode ? 12 : 16;
+  }
 
   @override
   _HarpyTabState createState() => _HarpyTabState();
@@ -111,7 +118,7 @@ class _HarpyTabState extends State<HarpyTab>
         child: Card(
           color: widget.cardColor,
           child: Padding(
-            padding: const EdgeInsets.all(HarpyTab.tabPadding),
+            padding: EdgeInsets.all(HarpyTab.tabPadding(context)),
             child: IconTheme(
               data: iconTheme.copyWith(
                 color: _colorAnimation.value,

--- a/lib/harpy_widgets/harpy_tab/harpy_tab_bar.dart
+++ b/lib/harpy_widgets/harpy_tab/harpy_tab_bar.dart
@@ -9,12 +9,18 @@ class HarpyTabBar extends StatefulWidget {
   const HarpyTabBar({
     required this.tabs,
     this.endWidgets,
+    this.padding,
   });
 
   final List<Widget> tabs;
 
   /// A list of additional widgets that will be built at the end of the tab bar.
   final List<Widget>? endWidgets;
+
+  /// Padding around the [tabs] inside the scroll view.
+  ///
+  /// Defaults to horizontal default edge insets.
+  final EdgeInsets? padding;
 
   @override
   _HarpyTapBarState createState() => _HarpyTapBarState();
@@ -97,27 +103,24 @@ class _HarpyTapBarState extends State<HarpyTabBar> {
   Widget build(BuildContext context) {
     final config = context.watch<ConfigCubit>().state;
 
-    return Center(
-      child: SingleChildScrollView(
-        controller: _scrollController,
-        scrollDirection: Axis.horizontal,
-        child: Padding(
-          padding: config.edgeInsetsSymmetric(horizontal: true),
-          child: Row(
-            children: [
-              for (int i = 0; i < widget.tabs.length; i++) ...[
-                _buildTab(i),
-                if (i != widget.tabs.length - 1) defaultSmallHorizontalSpacer,
-              ],
-              if (widget.endWidgets != null) ...[
-                for (Widget widget in widget.endWidgets!) ...[
-                  defaultSmallHorizontalSpacer,
-                  widget,
-                ],
-              ],
+    return SingleChildScrollView(
+      controller: _scrollController,
+      scrollDirection: Axis.horizontal,
+      padding: widget.padding ?? config.edgeInsetsSymmetric(horizontal: true),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (int i = 0; i < widget.tabs.length; i++) ...[
+            _buildTab(i),
+            if (i != widget.tabs.length - 1) defaultSmallHorizontalSpacer,
+          ],
+          if (widget.endWidgets != null) ...[
+            for (Widget widget in widget.endWidgets!) ...[
+              defaultSmallHorizontalSpacer,
+              widget,
             ],
-          ),
-        ),
+          ],
+        ],
       ),
     );
   }

--- a/lib/harpy_widgets/sliver_tab_view/harpy_sliver_tab_bar.dart
+++ b/lib/harpy_widgets/sliver_tab_view/harpy_sliver_tab_bar.dart
@@ -18,8 +18,10 @@ class HarpySliverTapBar extends StatelessWidget {
     return SliverToBoxAdapter(
       child: Padding(
         padding: config.edgeInsetsOnly(top: true),
-        child: HarpyTabBar(
-          tabs: tabs,
+        child: Center(
+          child: HarpyTabBar(
+            tabs: tabs,
+          ),
         ),
       ),
     );

--- a/lib/harpy_widgets/theme/harpy_theme.dart
+++ b/lib/harpy_widgets/theme/harpy_theme.dart
@@ -131,7 +131,7 @@ class HarpyTheme {
           )!;
 
     alternateCardColor =
-        Color.lerp(cardColor, averageBackgroundColor, .9)!.withOpacity(.8);
+        Color.lerp(cardColor, averageBackgroundColor, .9)!.withOpacity(.9);
 
     solidCardColor1 =
         Color.lerp(cardColor, averageBackgroundColor, .85)!.withOpacity(1);


### PR DESCRIPTION
- Reduces height of app bar by removing the title and actions button
  - the tab bar is moved up together with the drawer button
- Removes floating action buttons in the home content views (compose tweet button & media tiling button)
- Actions are moved as a top sliver in the content view
  - timeline: refresh, compose, filter
  - media: tiling
- Adds an option to display the app bar at the bottom
- Adds some style changes