### PR TITLE
Add unread tweet counter in home timeline

### DIFF
--- a/android/fastlane/metadata/android/free/en-US/changelogs/62.txt
+++ b/android/fastlane/metadata/android/free/en-US/changelogs/62.txt
@@ -1,5 +1,6 @@
 Version 0.6.13
 2021-xx-xx
 
+· Added unread tweets counter in home timeline
 · Updated home drawer
 · Minor style improvements

--- a/lib/components/common/timeline/home_timeline/widgets/home_timeline.dart
+++ b/lib/components/common/timeline/home_timeline/widgets/home_timeline.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:harpy/api/api.dart';
 import 'package:harpy/components/components.dart';
+import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 
 class HomeTimeline extends StatefulWidget {
   const HomeTimeline();
@@ -13,11 +14,24 @@ class HomeTimeline extends StatefulWidget {
 class _HomeTimelineState extends State<HomeTimeline> {
   late ScrollController _controller;
 
+  /// The index of the newest visible tweet.
+  int _newestVisibleIndex = 0;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
 
     _controller = PrimaryScrollController.of(context)!;
+  }
+
+  void _onLayoutFinished(int firstIndex, int lastIndex) {
+    final index = firstIndex ~/ 2;
+
+    if (_newestVisibleIndex != index) {
+      WidgetsBinding.instance!.addPostFrameCallback((_) {
+        setState(() => _newestVisibleIndex = index);
+      });
+    }
   }
 
   void _blocListener(BuildContext context, HomeTimelineState state) {
@@ -65,6 +79,7 @@ class _HomeTimelineState extends State<HomeTimeline> {
       listener: _blocListener,
       child: ScrollToStart(
         controller: _controller,
+        text: AnimatedNumber(number: _newestVisibleIndex),
         child: CustomRefreshIndicator(
           onRefresh: () async {
             ScrollDirection.of(context)!.reset();
@@ -82,6 +97,7 @@ class _HomeTimelineState extends State<HomeTimeline> {
               key: const PageStorageKey<String>('home_timeline'),
               controller: _controller,
               tweetBuilder: (tweet) => _tweetBuilder(state, tweet),
+              onLayoutFinished: _onLayoutFinished,
               enableScroll: state.hasTweets,
               beginSlivers: [
                 const HomeTopSliverPadding(),

--- a/lib/components/common/timeline/home_timeline/widgets/home_timeline.dart
+++ b/lib/components/common/timeline/home_timeline/widgets/home_timeline.dart
@@ -4,6 +4,9 @@ import 'package:harpy/api/api.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/harpy_widgets/harpy_widgets.dart';
 
+// todo: move `ScrollToStart` widget to the `TweetList` and enable unread
+//   counter for every tweet list
+
 class HomeTimeline extends StatefulWidget {
   const HomeTimeline();
 

--- a/lib/components/common/tweet/widgets/tweet_list.dart
+++ b/lib/components/common/tweet/widgets/tweet_list.dart
@@ -5,6 +5,10 @@ import 'package:provider/provider.dart';
 
 typedef TweetBuilder = Widget Function(TweetData tweet);
 
+/// Signature for a function that is called at the end of layout in the list
+/// builder.
+typedef OnLayoutFinished = void Function(int firstIndex, int lastIndex);
+
 /// Builds a [CustomScrollView] for the [tweets].
 ///
 /// An optional list of [beginSlivers] are built before the [tweets] and
@@ -14,6 +18,7 @@ class TweetList extends StatelessWidget {
     this.tweets, {
     this.controller,
     this.tweetBuilder = defaultTweetBuilder,
+    this.onLayoutFinished,
     this.beginSlivers = const [],
     this.endSlivers = const [],
     this.enableScroll = true,
@@ -26,6 +31,8 @@ class TweetList extends StatelessWidget {
   final ScrollController? controller;
 
   final TweetBuilder tweetBuilder;
+
+  final OnLayoutFinished? onLayoutFinished;
 
   /// Slivers built at the beginning of the [CustomScrollView].
   final List<Widget> beginSlivers;
@@ -63,15 +70,34 @@ class TweetList extends StatelessWidget {
         SliverPadding(
           padding: config.edgeInsets,
           sliver: SliverList(
-            delegate: SliverChildBuilderDelegate(
+            delegate: _TweetListBuilderDelegate(
               _itemBuilder,
+              onLayoutFinished: onLayoutFinished,
               childCount: tweets.length * 2 - 1,
-              addAutomaticKeepAlives: false,
             ),
           ),
         ),
         ...endSlivers,
       ],
     );
+  }
+}
+
+class _TweetListBuilderDelegate extends SliverChildBuilderDelegate {
+  _TweetListBuilderDelegate(
+    NullableIndexedWidgetBuilder builder, {
+    this.onLayoutFinished,
+    int? childCount,
+  }) : super(
+          builder,
+          childCount: childCount,
+          addAutomaticKeepAlives: false,
+        );
+
+  final OnLayoutFinished? onLayoutFinished;
+
+  @override
+  void didFinishLayout(int firstIndex, int lastIndex) {
+    onLayoutFinished?.call(firstIndex, lastIndex);
   }
 }

--- a/lib/components/widgets/list/scroll_to_start.dart
+++ b/lib/components/widgets/list/scroll_to_start.dart
@@ -16,10 +16,12 @@ import 'package:provider/provider.dart';
 class ScrollToStart extends StatefulWidget {
   const ScrollToStart({
     required this.child,
+    this.text,
     this.controller,
   });
 
   final Widget child;
+  final Widget? text;
   final ScrollController? controller;
 
   @override
@@ -64,7 +66,6 @@ class _ScrollToStartState extends State<ScrollToStart> {
     }
   }
 
-  /// Determines if the button should show.
   bool _show(MediaQueryData mediaQuery, ScrollDirection? scrollDirection) {
     if (_controller == null || !_controller!.hasClients) {
       return false;
@@ -130,6 +131,7 @@ class _ScrollToStartState extends State<ScrollToStart> {
                     CupertinoIcons.arrow_up,
                     color: harpyTheme.foregroundColor,
                   ),
+                  text: widget.text,
                   backgroundColor: harpyTheme.alternateCardColor,
                   onTap: () => _scrollToStart(mediaQuery),
                 ),

--- a/lib/components/widgets/list/scroll_to_start.dart
+++ b/lib/components/widgets/list/scroll_to_start.dart
@@ -78,17 +78,11 @@ class _ScrollToStartState extends State<ScrollToStart> {
   }
 
   void _scrollToStart(MediaQueryData mediaQuery) {
-    // ignore: invalid_use_of_protected_member
     if (!_hasSingleScrollPosition ||
         _controller!.offset > mediaQuery.size.height * 5) {
-      // We use animateTo instead of jumpTo because jumpTo(0) will cause the
-      // refresh indicator to trigger.
+      // jumpTo(0) will cause the refresh indicator to trigger.
       // todo: fixed in flutter:master, change to jumpTo when it hits stable
-      _controller!.animateTo(
-        0,
-        duration: const Duration(microseconds: 1),
-        curve: Curves.linear,
-      );
+      _controller!.jumpTo(1);
     } else {
       _controller!.animateTo(
         0,

--- a/lib/core/preferences/tweet_visibility_preferences.dart
+++ b/lib/core/preferences/tweet_visibility_preferences.dart
@@ -7,7 +7,6 @@ class TweetVisibilityPreferences {
   /// The id of the list visible tweet in the home timeline.
   int get lastVisibleTweet =>
       harpyPrefs.getInt('lastVisibleTweet', 0, prefix: true);
-  // int get lastVisibleTweet => 1425755631819108354;
 
   set lastVisibleTweet(int value) =>
       harpyPrefs.setInt('lastVisibleTweet', value, prefix: true);
@@ -15,7 +14,7 @@ class TweetVisibilityPreferences {
   void updateVisibleTweet(TweetData tweet) {
     final id = int.tryParse(tweet.originalId);
 
-    if (id != null /* && id > lastVisibleTweet */) {
+    if (id != null && id > lastVisibleTweet) {
       lastVisibleTweet = id;
     }
   }

--- a/lib/core/preferences/tweet_visibility_preferences.dart
+++ b/lib/core/preferences/tweet_visibility_preferences.dart
@@ -7,13 +7,15 @@ class TweetVisibilityPreferences {
   /// The id of the list visible tweet in the home timeline.
   int get lastVisibleTweet =>
       harpyPrefs.getInt('lastVisibleTweet', 0, prefix: true);
+  // int get lastVisibleTweet => 1425755631819108354;
+
   set lastVisibleTweet(int value) =>
       harpyPrefs.setInt('lastVisibleTweet', value, prefix: true);
 
   void updateVisibleTweet(TweetData tweet) {
     final id = int.tryParse(tweet.originalId);
 
-    if (id != null && id > lastVisibleTweet) {
+    if (id != null /* && id > lastVisibleTweet */) {
       lastVisibleTweet = id;
     }
   }

--- a/lib/harpy_widgets/animations/implicit/animated_number.dart
+++ b/lib/harpy_widgets/animations/implicit/animated_number.dart
@@ -65,10 +65,12 @@ class _AnimatedNumberState extends State<AnimatedNumber>
 
     if (oldWidget.number != widget.number) {
       _newNumberStr = widget.numberFormat.format(widget.number);
-      _controller.forward(from: 0).then((_) {
-        _oldNumberStr = _newNumberStr;
-        _oldNumber = widget.number;
-      });
+      if (!_controller.isAnimating) {
+        _controller.forward(from: 0).then((_) {
+          _oldNumberStr = _newNumberStr;
+          _oldNumber = widget.number;
+        });
+      }
     }
   }
 

--- a/lib/harpy_widgets/animations/implicit/animated_number.dart
+++ b/lib/harpy_widgets/animations/implicit/animated_number.dart
@@ -108,33 +108,35 @@ class _AnimatedNumberState extends State<AnimatedNumber>
       );
 
       return ClipRect(
-        child: AnimatedBuilder(
-          animation: _controller,
-          builder: (_, __) => Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(unchanged),
-              Stack(
-                fit: StackFit.passthrough,
-                children: [
-                  FractionalTranslation(
-                    translation: _oldNumber! > widget.number!
-                        ? _newSlideAnimation.value
-                        : -_newSlideAnimation.value,
-                    child: Text(newText),
-                  ),
-                  Opacity(
-                    opacity: _opacityAnimation.value,
-                    child: FractionalTranslation(
+        child: CustomAnimatedSize(
+          child: AnimatedBuilder(
+            animation: _controller,
+            builder: (_, __) => Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(unchanged),
+                Stack(
+                  fit: StackFit.passthrough,
+                  children: [
+                    FractionalTranslation(
                       translation: _oldNumber! > widget.number!
-                          ? _oldSlideAnimation.value
-                          : -_oldSlideAnimation.value,
-                      child: Text(oldText),
+                          ? _newSlideAnimation.value
+                          : -_newSlideAnimation.value,
+                      child: Text(newText),
                     ),
-                  ),
-                ],
-              )
-            ],
+                    Opacity(
+                      opacity: _opacityAnimation.value,
+                      child: FractionalTranslation(
+                        translation: _oldNumber! > widget.number!
+                            ? _oldSlideAnimation.value
+                            : -_oldSlideAnimation.value,
+                        child: Text(oldText),
+                      ),
+                    ),
+                  ],
+                )
+              ],
+            ),
           ),
         ),
       );


### PR DESCRIPTION
Adds a counter of unread tweets in the home timeline.

Follow up: Move the responsibility of showing the scroll to start button with the unread tweets from the home timeline to the tweet list (#412)

Closes #324 