### PR TITLE
Bump AGP to 7.0.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.2.2'
+    classpath 'com.android.tools.build:gradle:7.0.2'
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  android_path_provider: ^0.2.1
+  android_path_provider: ^0.3.0
   args: ^2.3.0
   bloc: ^7.1.0
   collection: ^1.15.0


### PR DESCRIPTION
- [android_path_provider 0.3.0](https://pub.dev/packages/android_path_provider) is out, to solve #426.
- After the migration, can bump AGP also.