### PR TITLE
Improve right-to-left langauge layout

### DIFF
--- a/.github/workflows/flutter_pr.yml
+++ b/.github/workflows/flutter_pr.yml
@@ -16,5 +16,6 @@ jobs:
       - run: flutter packages pub run build_runner build
       - run: flutter analyze
       - run: flutter format . --set-exit-if-changed
+      - run: flutter pub run code_rules.dart
       - run: flutter test
       - run: flutter build appbundle --flavor free --dart-define=flavor=free

--- a/.github/workflows/flutter_push.yml
+++ b/.github/workflows/flutter_push.yml
@@ -16,4 +16,5 @@ jobs:
       - run: flutter packages pub run build_runner build
       - run: flutter analyze
       - run: flutter format . --set-exit-if-changed
+      - run: flutter pub run code_rules.dart
       - run: flutter test

--- a/assets/changelogs/82.txt
+++ b/assets/changelogs/82.txt
@@ -5,5 +5,5 @@ Version 0.9.3
   - For Arabic, Persian, Hebrew, Pashto and Urdu
   - Tweet text is now laid out based on the Tweet's language
   - This does not include the description of a user
+- Fixed translate language setting not persisting across 
 - Updated color picker styling
-

--- a/assets/changelogs/82.txt
+++ b/assets/changelogs/82.txt
@@ -1,5 +1,9 @@
 Version 0.9.3
 2022-xx-xx
 
+- Fixed & improved layout for right-to-left languages throughout the app
+  - For Arabic, Persian, Hebrew, Pashto and Urdu
+  - Tweet text is now laid out based on the Tweet's language
+  - This does not include the description of a user
 - Updated color picker styling
 

--- a/bin/code_rules.dart
+++ b/bin/code_rules.dart
@@ -1,0 +1,113 @@
+// ignore_for_file: avoid_print
+
+import 'dart:async';
+import 'dart:io';
+
+final _ignoreDirectionalityRegex = RegExp('// ignore: non_directional');
+
+class _Failure {
+  const _Failure(this.path, this.lineNumber, this.message);
+
+  final String path;
+  final int lineNumber;
+  final String message;
+}
+
+final rules = [
+  _createRule(
+    message: 'Use AlignmentDirectional instead of Alignment.',
+    targets: [' Alignment.', ' Alignment('],
+  ),
+  _createRule(
+    message: 'Use EdgeInsetsDirectional.only() instead of EdgeInsets.only().',
+    targets: [' EdgeInsets.only'],
+  ),
+  _createRule(
+    message: 'Use EdgeInsetsDirectional.fromSTEB() instead of '
+        'EdgeInsets.fromLTRB().',
+    targets: [' EdgeInsets.fromLTRB'],
+  ),
+  _createRule(
+    message: 'Use TextAlign.start instead of TextAlign.left.',
+    targets: [' TextAlign.left'],
+  ),
+  _createRule(
+    message: 'Use TextAlign.end instead of TextAlign.right.',
+    targets: [' TextAlign.right'],
+  ),
+  _createRule(
+    message: 'Use PositionedDirectional instead of Positioned.',
+    targets: [' Positioned('],
+  ),
+];
+
+final _failures = <_Failure>[];
+
+Future<void> main(List<String> args) async {
+  print('Running code rules checker...\n');
+
+  await _scanDirectory(Directory('lib'));
+  await _scanDirectory(Directory('test'));
+
+  if (_failures.isNotEmpty) {
+    final buffer = StringBuffer(
+      '''
+##########################
+# CODE RULE CHECK FAILED #
+##########################
+
+''',
+    );
+
+    for (final failure in _failures) {
+      buffer
+        ..writeln(failure.message)
+        ..writeln('${failure.path}:${failure.lineNumber}\n');
+    }
+
+    print(buffer);
+
+    exit(1);
+  }
+}
+
+Future<void> _scanDirectory(Directory directory) async {
+  await for (final entity in directory.list(recursive: true)) {
+    if (entity is File && entity.path.endsWith('.dart')) {
+      await _checkFile(entity);
+    }
+  }
+}
+
+Future<void> _checkFile(File file) async {
+  final lines = file.readAsLinesSync();
+
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+
+    if (line.contains(_ignoreDirectionalityRegex)) {
+      // ignore this and the next line
+      i++;
+      continue;
+    }
+
+    for (final rule in rules) {
+      final result = await rule(line);
+
+      if (result != null) _failures.add(_Failure(file.path, i + 1, result));
+    }
+  }
+}
+
+FutureOr<String?> Function(String line) _createRule({
+  required List<Pattern> targets,
+  required String message,
+}) {
+  return (line) {
+    if (targets.any((target) => line.contains(target))) {
+      return message;
+    }
+
+    return null;
+  };
+}

--- a/lib/api/twitter/data/tweet_data.dart
+++ b/lib/api/twitter/data/tweet_data.dart
@@ -130,6 +130,7 @@ class TweetData with _$TweetData {
   late final hasText = visibleText.isNotEmpty;
   late final hasParent = parentTweetId != null && parentTweetId!.isNotEmpty;
   late final tweetUrl = 'https://twitter.com/${user.handle}/status/$id';
+  late final isRtlLanguage = rtlLanguageCodes.contains(lang);
 
   /// A concatenated string of the user names from the [replies].
   String get replyAuthors {

--- a/lib/components/changelog/widget/changelog_widget.dart
+++ b/lib/components/changelog/widget/changelog_widget.dart
@@ -101,7 +101,7 @@ class _ChangelogEntry extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: const EdgeInsets.only(top: 2),
+          padding: const EdgeInsetsDirectional.only(top: 2),
           child: entry.type.asIcon,
         ),
         horizontalSpacer,

--- a/lib/components/compose/widgets/compose_media.dart
+++ b/lib/components/compose/widgets/compose_media.dart
@@ -30,7 +30,7 @@ class ComposeMedia extends ConsumerWidget {
             else if (state.type == MediaType.video)
               ComposeVideo(media: state.media!.single),
             Align(
-              alignment: Alignment.topRight,
+              alignment: AlignmentDirectional.topEnd,
               child: HarpyButton.card(
                 icon: const Icon(CupertinoIcons.xmark),
                 onTap: notifier.clear,

--- a/lib/components/home/tab_configuration/widgets/home_tab_entry_icon.dart
+++ b/lib/components/home/tab_configuration/widgets/home_tab_entry_icon.dart
@@ -79,7 +79,7 @@ class HomeTabEntryIcon extends StatelessWidget {
       return Container(
         width: size,
         height: size,
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         child: Text(
           iconName!,
           style: TextStyle(

--- a/lib/components/home/tab_configuration/widgets/home_tab_reorder_card.dart
+++ b/lib/components/home/tab_configuration/widgets/home_tab_reorder_card.dart
@@ -25,7 +25,7 @@ class HomeTabReorderCard extends ConsumerWidget {
       duration: kShortAnimationDuration,
       opacity: entry.visible ? 1 : .6,
       child: Card(
-        margin: EdgeInsets.only(bottom: display.smallPaddingValue),
+        margin: EdgeInsetsDirectional.only(bottom: display.smallPaddingValue),
         child: Row(
           children: [
             _HomeTabIcon(index: index, entry: entry),
@@ -51,7 +51,7 @@ class HomeTabReorderCard extends ConsumerWidget {
             HarpyReorderableDragStartListener(
               index: index,
               child: Container(
-                padding: display.edgeInsets.copyWith(left: 0),
+                padding: display.edgeInsets.copyWith(start: 0),
                 color: Colors.transparent,
                 child: const Icon(CupertinoIcons.bars),
               ),

--- a/lib/components/home/widgets/floating_compose_button.dart
+++ b/lib/components/home/widgets/floating_compose_button.dart
@@ -58,7 +58,7 @@ class _FloatingComposeButtonState extends ConsumerState<FloatingComposeButton> {
       children: [
         widget.child,
         Align(
-          alignment: Alignment.bottomRight,
+          alignment: AlignmentDirectional.bottomEnd,
           child: AnimatedOpacity(
             opacity: show ? 1 : 0,
             curve: Curves.easeInOut,
@@ -92,9 +92,9 @@ class _ComposeButton extends ConsumerWidget {
         : display.paddingValue + mediaQuery.padding.bottom;
 
     return Padding(
-      padding: EdgeInsets.only(
+      padding: EdgeInsetsDirectional.only(
         bottom: bottomPadding,
-        right: display.paddingValue,
+        end: display.paddingValue,
       ),
       child: Material(
         color: harpyTheme.colors.alternateCardColor,

--- a/lib/components/home/widgets/home_app_bar.dart
+++ b/lib/components/home/widgets/home_app_bar.dart
@@ -33,16 +33,17 @@ class HomeAppBar extends ConsumerWidget {
         ? mediaQuery.padding.bottom + display.paddingValue / 2
         : 0.0;
 
-    final padding = EdgeInsets.only(
+    final padding = EdgeInsetsDirectional.only(
       top: topPadding,
       bottom: bottomPadding,
-      left: display.paddingValue,
-      right: display.paddingValue,
+      start: display.paddingValue,
+      end: display.paddingValue,
     );
 
     return Align(
-      alignment:
-          general.bottomAppBar ? Alignment.bottomCenter : Alignment.topCenter,
+      alignment: general.bottomAppBar
+          ? AlignmentDirectional.bottomCenter
+          : AlignmentDirectional.topCenter,
       child: general.hideHomeAppBar
           ? _DynamicAppBar(padding: padding)
           : HomeTabBar(padding: padding),
@@ -55,7 +56,7 @@ class _DynamicAppBar extends ConsumerWidget {
     required this.padding,
   });
 
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/components/home/widgets/home_drawer.dart
+++ b/lib/components/home/widgets/home_drawer.dart
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
 import 'package:harpy/rby/rby.dart';
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' as intl;
 
 typedef AnimatedWidgetBuilder = Widget Function(
   AnimationController controller,
@@ -149,7 +149,7 @@ class _AuthenticatedUser extends ConsumerWidget {
 class _FollowersCount extends ConsumerWidget {
   const _FollowersCount();
 
-  static final _numberFormat = NumberFormat.compact();
+  static final _numberFormat = intl.NumberFormat.compact();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -202,12 +202,22 @@ class _Entries extends ConsumerWidget {
 
   final AnimationController controller;
 
-  List<Widget> _animate(List<Widget> children) {
+  List<Widget> _animate(
+    List<Widget> children, {
+    required TextDirection directionality,
+  }) {
     final animated = <Widget>[];
 
     for (var i = 0; i < children.length; i++) {
       final offsetAnimation = Tween<Offset>(
-        begin: Offset(lerpDouble(-.3, -2, i / children.length)!, 0),
+        begin: Offset(
+          lerpDouble(
+            directionality == TextDirection.ltr ? -.3 : .3,
+            directionality == TextDirection.ltr ? -2 : 2,
+            i / children.length,
+          )!,
+          0,
+        ),
         end: Offset.zero,
       ).animate(controller);
 
@@ -231,6 +241,8 @@ class _Entries extends ConsumerWidget {
     final router = ref.watch(routerProvider);
     final general = ref.watch(generalPreferencesProvider);
     final user = ref.watch(authenticationStateProvider).user;
+
+    final directionality = Directionality.of(context);
 
     if (user == null) return const SizedBox();
 
@@ -310,7 +322,12 @@ class _Entries extends ConsumerWidget {
     return AnimatedBuilder(
       animation: controller,
       builder: (_, __) => Column(
-        children: general.performanceMode ? children : _animate(children),
+        children: general.performanceMode
+            ? children
+            : _animate(
+                children,
+                directionality: directionality,
+              ),
       ),
     );
   }

--- a/lib/components/home/widgets/home_tab_bar.dart
+++ b/lib/components/home/widgets/home_tab_bar.dart
@@ -10,12 +10,12 @@ class HomeTabBar extends ConsumerWidget {
     required this.padding,
   });
 
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   Widget _mapEntryTabs({
     required HomeTabEntry entry,
     required Color cardColor,
-    required EdgeInsets padding,
+    required EdgeInsetsGeometry padding,
   }) {
     return entry.type == HomeTabEntryType.defaultType && entry.id == 'mentions'
         ? _MentionsTab(entry: entry)

--- a/lib/components/list/show/widgets/twitter_list_card.dart
+++ b/lib/components/list/show/widgets/twitter_list_card.dart
@@ -127,6 +127,7 @@ class _ListUser extends StatelessWidget {
         smallHorizontalSpacer,
         Text(
           '@${list.user!.handle}',
+          textDirection: TextDirection.ltr,
           style: theme.textTheme.bodyText1,
           softWrap: false,
           overflow: TextOverflow.fade,

--- a/lib/components/login/login_page.dart
+++ b/lib/components/login/login_page.dart
@@ -96,7 +96,7 @@ class _AboutButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Align(
-      alignment: Alignment.topRight,
+      alignment: AlignmentDirectional.topEnd,
       child: HarpyButton.icon(
         icon: const Icon(Icons.info_outline),
         onTap: () => Navigator.of(context).push(
@@ -123,6 +123,7 @@ class _HarpyTitle extends StatelessWidget {
         curve: Curves.easeOutCubic,
         begin: const Offset(0, .5),
         child: FlareAnimation.harpyTitle(
+          // ignore: non_directional
           alignment: Alignment.bottomCenter,
           animation: 'show',
           color: theme.colorScheme.onBackground,

--- a/lib/components/settings/display/preferences/display_preferences.dart
+++ b/lib/components/settings/display/preferences/display_preferences.dart
@@ -85,29 +85,31 @@ class DisplayPreferences with _$DisplayPreferences {
   late final fontSizeDelta = _fontSizeDeltaIdMap[fontSizeDeltaId] ?? 0;
   late final paddingValue = compactMode ? 12.0 : 16.0;
   late final smallPaddingValue = paddingValue / 2;
-  late final edgeInsets = EdgeInsets.all(paddingValue);
+  late final edgeInsets = EdgeInsetsDirectional.all(paddingValue);
 
-  EdgeInsets edgeInsetsOnly({
-    bool left = false,
-    bool right = false,
+  EdgeInsetsDirectional edgeInsetsOnly({
+    bool start = false,
+    bool end = false,
     bool top = false,
     bool bottom = false,
   }) {
-    return EdgeInsets.only(
-      left: left ? paddingValue : 0,
-      right: right ? paddingValue : 0,
+    return EdgeInsetsDirectional.only(
+      start: start ? paddingValue : 0,
+      end: end ? paddingValue : 0,
       top: top ? paddingValue : 0,
       bottom: bottom ? paddingValue : 0,
     );
   }
 
-  EdgeInsets edgeInsetsSymmetric({
+  EdgeInsetsDirectional edgeInsetsSymmetric({
     bool horizontal = false,
     bool vertical = false,
   }) {
-    return EdgeInsets.symmetric(
-      horizontal: horizontal ? paddingValue : 0,
-      vertical: vertical ? paddingValue : 0,
+    return EdgeInsetsDirectional.only(
+      start: horizontal ? paddingValue : 0,
+      end: horizontal ? paddingValue : 0,
+      top: vertical ? paddingValue : 0,
+      bottom: vertical ? paddingValue : 0,
     );
   }
 }
@@ -120,3 +122,19 @@ const _fontSizeDeltaIdMap = <int, double>{
   1: 2,
   2: 4,
 };
+
+extension EdgeInsetsDirectionalExtension on EdgeInsetsDirectional {
+  EdgeInsetsDirectional copyWith({
+    double? start,
+    double? end,
+    double? top,
+    double? bottom,
+  }) {
+    return EdgeInsetsDirectional.only(
+      start: start ?? this.start,
+      end: end ?? this.end,
+      top: top ?? this.top,
+      bottom: bottom ?? this.bottom,
+    );
+  }
+}

--- a/lib/components/settings/language/preferences/language_preferences.dart
+++ b/lib/components/settings/language/preferences/language_preferences.dart
@@ -30,7 +30,7 @@ class LanguagePreferencesNotifier extends StateNotifier<LanguagePreferences> {
 
   void setTranslateLanguage(String value) {
     state = state.copyWith(translateLanguage: value);
-    _preferences.setString('translateLanguage', '');
+    _preferences.setString('translateLanguage', value);
   }
 }
 

--- a/lib/components/settings/theme/custom_theme/widgets/custom_theme_background_colors.dart
+++ b/lib/components/settings/theme/custom_theme/widgets/custom_theme_background_colors.dart
@@ -68,7 +68,9 @@ class _ReorderableBackgroundColors extends ConsumerWidget {
 
         return Padding(
           key: ValueKey(hashValues(color, index)),
-          padding: EdgeInsets.only(bottom: display.smallPaddingValue),
+          padding: EdgeInsetsDirectional.only(
+            bottom: display.smallPaddingValue,
+          ),
           child: ClipRRect(
             borderRadius: harpyTheme.borderRadius,
             child: CustomThemeColor(

--- a/lib/components/setup/setup_page.dart
+++ b/lib/components/setup/setup_page.dart
@@ -199,7 +199,7 @@ class _SkipButtonState extends ConsumerState<_SkipButton> {
       opacity: _opacity,
       child: Container(
         padding: display.edgeInsetsSymmetric(horizontal: true),
-        alignment: Alignment.centerLeft,
+        alignment: AlignmentDirectional.centerStart,
         child: HarpyButton.text(
           padding: display.edgeInsets,
           label: const Text('skip'),
@@ -256,7 +256,7 @@ class _PrevButtonState extends ConsumerState<_PrevButton> {
       opacity: _opacity,
       child: Container(
         padding: display.edgeInsetsSymmetric(horizontal: true),
-        alignment: Alignment.centerLeft,
+        alignment: AlignmentDirectional.centerStart,
         child: HarpyButton.text(
           padding: display.edgeInsets,
           icon: const Icon(CupertinoIcons.chevron_left),
@@ -323,7 +323,7 @@ class _NextButtonState extends ConsumerState<_NextButton> {
       opacity: _opacity,
       child: Container(
         padding: display.edgeInsetsSymmetric(horizontal: true),
-        alignment: Alignment.centerRight,
+        alignment: AlignmentDirectional.centerEnd,
         child: HarpyButton.text(
           padding: display.edgeInsets,
           icon: const Icon(CupertinoIcons.chevron_right),

--- a/lib/components/timeline/widgets/new_tweets_text.dart
+++ b/lib/components/timeline/widgets/new_tweets_text.dart
@@ -19,7 +19,7 @@ class NewTweetsText extends ConsumerWidget {
 
     return Container(
       padding: display.edgeInsetsSymmetric(horizontal: true),
-      alignment: Alignment.center,
+      alignment: AlignmentDirectional.center,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [

--- a/lib/components/trends/find_trends_location/widgets/find_custom_trends_location.dart
+++ b/lib/components/trends/find_trends_location/widgets/find_custom_trends_location.dart
@@ -41,7 +41,7 @@ class _FindCustomTrendsLocationState
           children: [
             AnimatedSize(
               duration: kShortAnimationDuration,
-              alignment: Alignment.topCenter,
+              alignment: AlignmentDirectional.topCenter,
               child: Padding(
                 padding: EdgeInsets.symmetric(
                   vertical: display.smallPaddingValue,

--- a/lib/components/trends/find_trends_location/widgets/found_trends_locations.dart
+++ b/lib/components/trends/find_trends_location/widgets/found_trends_locations.dart
@@ -15,7 +15,7 @@ class FoundTrendsLocations extends ConsumerWidget {
 
     return HarpyAnimatedSwitcher(
       layoutBuilder: (currentChild, previousChildren) => Stack(
-        alignment: Alignment.topCenter,
+        alignment: AlignmentDirectional.topCenter,
         children: [
           ...previousChildren,
           if (currentChild != null) currentChild,

--- a/lib/components/trends/widgets/trend_card.dart
+++ b/lib/components/trends/widgets/trend_card.dart
@@ -4,7 +4,7 @@ import 'package:flutter_feather_icons/flutter_feather_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' as intl;
 
 class TrendCard extends ConsumerWidget {
   const TrendCard({
@@ -13,13 +13,16 @@ class TrendCard extends ConsumerWidget {
 
   final Trend trend;
 
-  static final _numberFormat = NumberFormat.compact();
+  static final _numberFormat = intl.NumberFormat.compact();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return HarpyListCard(
       leading: const Icon(FeatherIcons.trendingUp, size: 18),
-      title: Text(trend.name ?? ''),
+      title: Text(
+        trend.name ?? '',
+        textDirection: TextDirection.ltr,
+      ),
       subtitle: trend.tweetVolume != null
           ? Text('${_numberFormat.format(trend.tweetVolume)} tweets')
           : null,

--- a/lib/components/trends/widgets/trends_location_selection_dialog.dart
+++ b/lib/components/trends/widgets/trends_location_selection_dialog.dart
@@ -67,7 +67,7 @@ class _LocationSelectionDialogState
           if (locations is AsyncLoading)
             Container(
               padding: display.edgeInsets,
-              alignment: Alignment.center,
+              alignment: AlignmentDirectional.center,
               child: const CircularProgressIndicator(),
             )
         ],

--- a/lib/components/tweet/detail/widgets/tweet_detail_header.dart
+++ b/lib/components/tweet/detail/widgets/tweet_detail_header.dart
@@ -27,7 +27,7 @@ class TweetDetailHeader extends ConsumerWidget {
       child: AnimatedSize(
         duration: kLongAnimationDuration,
         curve: Curves.easeOutCubic,
-        alignment: Alignment.topCenter,
+        alignment: AlignmentDirectional.topCenter,
         child: parent != null
             ? Column(
                 children: [

--- a/lib/components/tweet/widgets/button/tweet_action_button.dart
+++ b/lib/components/tweet/widgets/button/tweet_action_button.dart
@@ -152,7 +152,7 @@ class _TweetActionButtonState extends ConsumerState<TweetActionButton>
       overlayColor: MaterialStateProperty.all(theme.highlightColor),
       elevation: MaterialStateProperty.all(0),
       padding: MaterialStateProperty.all(
-        display.edgeInsets + EdgeInsets.all(widget.sizeDelta),
+        display.edgeInsets + EdgeInsetsDirectional.all(widget.sizeDelta),
       ),
     );
 
@@ -162,7 +162,7 @@ class _TweetActionButtonState extends ConsumerState<TweetActionButton>
       style: style,
       child: AnimatedSize(
         duration: kShortAnimationDuration,
-        alignment: Alignment.centerLeft,
+        alignment: AlignmentDirectional.centerStart,
         child: Row(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.end,

--- a/lib/components/tweet/widgets/card_content/tweet_card_handle.dart
+++ b/lib/components/tweet/widgets/card_content/tweet_card_handle.dart
@@ -22,37 +22,48 @@ class TweetCardHandle extends ConsumerWidget {
     final theme = Theme.of(context);
     final display = ref.watch(displayPreferencesProvider);
 
+    final directionality = Directionality.of(context);
+
+    final textSpans = [
+      TextSpan(
+        text: '@${tweet.user.handle}',
+        style: theme.textTheme.bodyText1!
+            .copyWith(height: 1)
+            .apply(fontSizeDelta: style.sizeDelta),
+      ),
+      TextSpan(
+        text: ' \u00b7 ',
+        style: theme.textTheme.bodyText1!
+            .copyWith(height: 1)
+            .apply(fontSizeDelta: style.sizeDelta),
+      ),
+      WidgetSpan(
+        alignment: PlaceholderAlignment.baseline,
+        baseline: TextBaseline.alphabetic,
+        child: display.absoluteTweetTime
+            ? _CreatedAtAbsoluteTime(
+                localCreatedAt: tweet.createdAt.toLocal(),
+                sizeDelta: style.sizeDelta,
+              )
+            : _CreatedAtRelativeTime(
+                localCreatedAt: tweet.createdAt.toLocal(),
+                sizeDelta: style.sizeDelta,
+              ),
+      ),
+    ];
+
     return FittedBox(
       child: GestureDetector(
         onTap: () => onUserTap?.call(context, ref.read),
         child: Text.rich(
+          // we force the text direction to ltr, otherwise the `@handle` gets
+          // reversed to `handle@` for rtl languages
+          textDirection: TextDirection.ltr,
           TextSpan(
             children: [
-              TextSpan(
-                text: '@${tweet.user.handle}',
-                style: theme.textTheme.bodyText1!
-                    .copyWith(height: 1)
-                    .apply(fontSizeDelta: style.sizeDelta),
-              ),
-              TextSpan(
-                text: ' \u00b7 ',
-                style: theme.textTheme.bodyText1!
-                    .copyWith(height: 1)
-                    .apply(fontSizeDelta: style.sizeDelta),
-              ),
-              WidgetSpan(
-                alignment: PlaceholderAlignment.baseline,
-                baseline: TextBaseline.alphabetic,
-                child: display.absoluteTweetTime
-                    ? _CreatedAtAbsoluteTime(
-                        localCreatedAt: tweet.createdAt.toLocal(),
-                        sizeDelta: style.sizeDelta,
-                      )
-                    : _CreatedAtRelativeTime(
-                        localCreatedAt: tweet.createdAt.toLocal(),
-                        sizeDelta: style.sizeDelta,
-                      ),
-              ),
+              ...directionality == TextDirection.ltr
+                  ? textSpans
+                  : textSpans.reversed,
             ],
           ),
         ),
@@ -107,6 +118,7 @@ class _CreatedAtRelativeTimeState extends State<_CreatedAtRelativeTime> {
 
     return Text(
       timeago.format(widget.localCreatedAt, locale: languageCode),
+      textDirection: TextDirection.ltr,
       style: theme.textTheme.bodyText1!
           .copyWith(height: 1)
           .apply(fontSizeDelta: widget.sizeDelta),
@@ -137,6 +149,7 @@ class _CreatedAtAbsoluteTime extends StatelessWidget {
     return FittedBox(
       child: Text(
         '$time \u00b7 $date',
+        textDirection: TextDirection.ltr,
         style: theme.textTheme.bodyText1!
             .copyWith(height: 1)
             .apply(fontSizeDelta: sizeDelta),

--- a/lib/components/tweet/widgets/card_content/tweet_card_retweeter.dart
+++ b/lib/components/tweet/widgets/card_content/tweet_card_retweeter.dart
@@ -36,16 +36,18 @@ class TweetCardRetweeter extends ConsumerWidget {
             ),
             horizontalSpacer,
             Flexible(
-              child: Text(
-                '${tweet.retweeter!.name} retweeted',
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: textStyle
-                    .copyWith(
-                      color: textStyle.color?.withOpacity(.8),
-                      height: 1,
-                    )
-                    .apply(fontSizeDelta: style.sizeDelta),
+              child: FittedBox(
+                child: Text(
+                  '${tweet.retweeter!.name} retweeted',
+                  textDirection: TextDirection.ltr,
+                  maxLines: 1,
+                  style: textStyle
+                      .copyWith(
+                        color: textStyle.color?.withOpacity(.8),
+                        height: 1,
+                      )
+                      .apply(fontSizeDelta: style.sizeDelta),
+                ),
               ),
             ),
           ],

--- a/lib/components/tweet/widgets/card_content/tweet_card_text.dart
+++ b/lib/components/tweet/widgets/card_content/tweet_card_text.dart
@@ -15,11 +15,15 @@ class TweetCardText extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return TwitterText(
-      tweet.text,
-      entities: tweet.entities,
-      urlToIgnore: tweet.quoteUrl,
-      style: theme.textTheme.bodyText2!.apply(fontSizeDelta: style.sizeDelta),
+    return Directionality(
+      textDirection:
+          tweet.isRtlLanguage ? TextDirection.rtl : TextDirection.ltr,
+      child: TwitterText(
+        tweet.text,
+        entities: tweet.entities,
+        urlToIgnore: tweet.quoteUrl,
+        style: theme.textTheme.bodyText2!.apply(fontSizeDelta: style.sizeDelta),
+      ),
     );
   }
 }

--- a/lib/components/tweet/widgets/card_content/tweet_card_top_row.dart
+++ b/lib/components/tweet/widgets/card_content/tweet_card_top_row.dart
@@ -75,7 +75,7 @@ class TweetCardTopRow extends ConsumerWidget {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          if (name)
+                          if (name && tweet.user.name.isNotEmpty)
                             TweetCardName(
                               tweet: tweet,
                               onUserTap: delegates.onShowUser,

--- a/lib/components/tweet/widgets/media/media_gallery_overlay.dart
+++ b/lib/components/tweet/widgets/media/media_gallery_overlay.dart
@@ -110,7 +110,7 @@ class _MediaOverlayState extends ConsumerState<MediaGalleryOverlay>
 
     final appBar = Align(
       key: _appBarKey,
-      alignment: Alignment.topCenter,
+      alignment: AlignmentDirectional.topCenter,
       child: SlideTransition(
         position: _topAnimation,
         child: const _OverlayAppBar(),
@@ -119,7 +119,7 @@ class _MediaOverlayState extends ConsumerState<MediaGalleryOverlay>
 
     final actions = Align(
       key: _actionsKey,
-      alignment: Alignment.bottomCenter,
+      alignment: AlignmentDirectional.bottomCenter,
       child: SlideTransition(
         position: _bottomAnimation,
         child: _OverlayTweetActions(
@@ -167,12 +167,12 @@ class _OverlayAppBar extends ConsumerWidget {
         child: GestureDetector(
           onTap: Navigator.of(context).maybePop,
           child: Container(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             width: double.infinity,
             decoration: const BoxDecoration(
               gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
+                begin: AlignmentDirectional.topCenter,
+                end: AlignmentDirectional.bottomCenter,
                 colors: [Colors.black87, Colors.transparent],
               ),
             ),
@@ -268,8 +268,8 @@ class _OverlayTweetActions extends ConsumerWidget {
     return Container(
       decoration: const BoxDecoration(
         gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
+          begin: AlignmentDirectional.topCenter,
+          end: AlignmentDirectional.bottomCenter,
           colors: [Colors.transparent, Colors.black87],
         ),
       ),
@@ -310,17 +310,21 @@ class _OverlayPreviewText extends ConsumerWidget {
     final display = ref.watch(displayPreferencesProvider);
 
     return Padding(
-      padding: display.edgeInsetsSymmetric(horizontal: true) +
-          EdgeInsets.symmetric(vertical: display.smallPaddingValue),
+      padding: EdgeInsetsDirectional.only(
+        start: display.paddingValue,
+        end: display.paddingValue,
+        top: display.smallPaddingValue,
+        bottom: display.smallPaddingValue,
+      ),
       child: AnimatedSize(
         duration: kShortAnimationDuration,
-        alignment: Alignment.bottomCenter,
+        alignment: AlignmentDirectional.bottomCenter,
         curve: Curves.easeInOut,
         child: GestureDetector(
           onTap: () => delegates.onShowTweet?.call(context, ref.read),
           child: HarpyAnimatedSwitcher(
             layoutBuilder: (currentChild, previousChildren) => Stack(
-              alignment: Alignment.bottomCenter,
+              alignment: AlignmentDirectional.bottomCenter,
               children: [
                 ...previousChildren,
                 if (currentChild != null) currentChild,

--- a/lib/components/tweet/widgets/media/media_thumbnail.dart
+++ b/lib/components/tweet/widgets/media/media_thumbnail.dart
@@ -29,7 +29,7 @@ class MediaThumbnail extends ConsumerWidget {
       onTap: onTap ?? () {},
       onLongPress: onLongPress,
       child: Stack(
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         children: [
           HarpyImage(
             imageUrl: thumbnail.appropriateUrl(mediaPreferences, connectivity),

--- a/lib/components/tweet/widgets/media/overlays/dynamic_video_player_overlay.dart
+++ b/lib/components/tweet/widgets/media/overlays/dynamic_video_player_overlay.dart
@@ -77,7 +77,7 @@ class _DynamicVideoPlayerOverlayState extends State<DynamicVideoPlayerOverlay>
       // the overlay)
       onTap: () {},
       child: Stack(
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         children: [
           GestureDetector(
             onTap: () {
@@ -96,7 +96,7 @@ class _DynamicVideoPlayerOverlayState extends State<DynamicVideoPlayerOverlay>
             data: widget.data,
           ),
           Align(
-            alignment: Alignment.bottomCenter,
+            alignment: AlignmentDirectional.bottomCenter,
             child: ClipRect(
               child: IgnorePointer(
                 ignoring: !_showActions,

--- a/lib/components/tweet/widgets/media/overlays/gif_video_player_overlay.dart
+++ b/lib/components/tweet/widgets/media/overlays/gif_video_player_overlay.dart
@@ -23,7 +23,7 @@ class GifVideoPlayerOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
-      alignment: Alignment.center,
+      alignment: AlignmentDirectional.center,
       children: [
         GestureDetector(
           onTap: onGifTap ??

--- a/lib/components/tweet/widgets/media/overlays/small_video_player_overlay.dart
+++ b/lib/components/tweet/widgets/media/overlays/small_video_player_overlay.dart
@@ -61,7 +61,7 @@ class _SmallVideoPlayerOverlayState
       // the overlay)
       onTap: () {},
       child: Stack(
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         children: [
           GestureDetector(
             onTap: () {
@@ -83,7 +83,7 @@ class _SmallVideoPlayerOverlayState
             compact: true,
           ),
           Align(
-            alignment: Alignment.bottomCenter,
+            alignment: AlignmentDirectional.bottomCenter,
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/lib/components/tweet/widgets/media/overlays/static_video_player_overlay.dart
+++ b/lib/components/tweet/widgets/media/overlays/static_video_player_overlay.dart
@@ -53,7 +53,7 @@ class _StaticVideoPlayerOverlayState extends State<StaticVideoPlayerOverlay>
       // the overlay)
       onTap: () {},
       child: Stack(
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         children: [
           GestureDetector(
             onTap: () {
@@ -74,7 +74,7 @@ class _StaticVideoPlayerOverlayState extends State<StaticVideoPlayerOverlay>
             data: widget.data,
           ),
           Align(
-            alignment: Alignment.bottomCenter,
+            alignment: AlignmentDirectional.bottomCenter,
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/lib/components/tweet/widgets/media/overlays/video_player_actions.dart
+++ b/lib/components/tweet/widgets/media/overlays/video_player_actions.dart
@@ -21,8 +21,8 @@ class VideoPlayerActions extends ConsumerWidget {
     return DecoratedBox(
       decoration: const BoxDecoration(
         gradient: LinearGradient(
-          begin: Alignment.bottomCenter,
-          end: Alignment.topCenter,
+          begin: AlignmentDirectional.bottomCenter,
+          end: AlignmentDirectional.topCenter,
           colors: [
             Colors.black45,
             Colors.transparent,

--- a/lib/components/tweet/widgets/tweet_card_content.dart
+++ b/lib/components/tweet/widgets/tweet_card_content.dart
@@ -78,7 +78,7 @@ class TweetCardContent extends ConsumerWidget {
 
     return Column(
       mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         for (var i = 0; i < content.length; i++) ...[
           if (!content.keys.elementAt(i).requiresPadding)

--- a/lib/components/user/widgets/header/user_description_translation.dart
+++ b/lib/components/user/widgets/header/user_description_translation.dart
@@ -27,7 +27,9 @@ class UserDescriptionTranslation extends ConsumerWidget {
         child: user.descriptionTranslation != null &&
                 user.descriptionTranslation!.isTranslated
             ? Padding(
-                padding: EdgeInsets.only(top: display.smallPaddingValue),
+                padding: EdgeInsetsDirectional.only(
+                  top: display.smallPaddingValue,
+                ),
                 child: TranslatedText(
                   user.descriptionTranslation!.text,
                   language: user.descriptionTranslation!.language,

--- a/lib/components/user/widgets/header/user_header.dart
+++ b/lib/components/user/widgets/header/user_header.dart
@@ -50,7 +50,7 @@ class UserHeader extends ConsumerWidget {
             AnimatedSize(
               duration: kShortAnimationDuration,
               curve: Curves.easeOutCubic,
-              alignment: Alignment.topCenter,
+              alignment: AlignmentDirectional.topCenter,
               child: Padding(
                 padding: display.edgeInsetsSymmetric(horizontal: true),
                 child: UserAdditionalInfo(user: user, connections: connections),

--- a/lib/components/user/widgets/header/user_info.dart
+++ b/lib/components/user/widgets/header/user_info.dart
@@ -38,12 +38,11 @@ class UserInfo extends ConsumerWidget {
                 children: [
                   Expanded(
                     child: Padding(
-                      padding: display
-                          .edgeInsetsOnly(
-                            top: true,
-                            right: true,
-                          )
-                          .copyWith(bottom: display.paddingValue),
+                      padding: display.edgeInsetsOnly(
+                        top: true,
+                        end: true,
+                        bottom: true,
+                      ),
                       child: _Handle(user: user),
                     ),
                   ),
@@ -65,7 +64,7 @@ class UserInfo extends ConsumerWidget {
                 ],
               ),
               Padding(
-                padding: display.edgeInsetsOnly(right: true),
+                padding: display.edgeInsetsOnly(end: true),
                 child: _Name(user: user),
               ),
             ],
@@ -166,8 +165,12 @@ class _Handle extends ConsumerWidget {
       },
       child: FittedBox(
         fit: BoxFit.scaleDown,
-        alignment: Alignment.centerLeft,
-        child: Text(handle, style: theme.textTheme.subtitle1),
+        alignment: AlignmentDirectional.centerStart,
+        child: Text(
+          handle,
+          textDirection: TextDirection.ltr,
+          style: theme.textTheme.subtitle1,
+        ),
       ),
     );
   }

--- a/lib/components/user/widgets/user_app_bar.dart
+++ b/lib/components/user/widgets/user_app_bar.dart
@@ -63,9 +63,9 @@ class _BackButton extends ConsumerWidget {
         curve: Curves.easeInOut,
         duration: kShortAnimationDuration,
         child: UnconstrainedBox(
-          alignment: Alignment.topLeft,
+          alignment: AlignmentDirectional.topStart,
           child: Padding(
-            padding: display.edgeInsetsOnly(left: true) / 2,
+            padding: display.edgeInsetsOnly(start: true) / 2,
             child: HarpyButton.card(
               icon: Transform.translate(
                 offset: const Offset(-1, 0),

--- a/lib/components/user/widgets/user_card.dart
+++ b/lib/components/user/widgets/user_card.dart
@@ -48,6 +48,7 @@ class UserCard extends ConsumerWidget {
                 children: [
                   Text(
                     '@${user.handle}',
+                    textDirection: TextDirection.ltr,
                     softWrap: false,
                     overflow: TextOverflow.fade,
                   ),

--- a/lib/components/widgets/filter/filter_switch_tile.dart
+++ b/lib/components/widgets/filter/filter_switch_tile.dart
@@ -26,10 +26,10 @@ class FilterSwitchTile extends ConsumerWidget {
 
     return SwitchListTile(
       value: value,
-      contentPadding: EdgeInsets.only(
-        left: display.paddingValue,
+      contentPadding: EdgeInsetsDirectional.only(
+        start: display.paddingValue,
         // - 8 since the check box icon has a padding of 8
-        right: max(display.paddingValue - 8, 0),
+        end: max(display.paddingValue - 8, 0),
       ),
       title: Text(
         text,

--- a/lib/components/widgets/flare_animation.dart
+++ b/lib/components/widgets/flare_animation.dart
@@ -20,12 +20,14 @@ Future<void> warmupFlare() async {
 
 class FlareAnimation extends StatelessWidget {
   const FlareAnimation.harpyTitle({
+    // ignore: non_directional
     this.alignment = Alignment.center,
     this.animation,
     this.color,
   }) : name = 'harpy_title';
 
   const FlareAnimation.harpyLogo({
+    // ignore: non_directional
     this.alignment = Alignment.center,
     this.animation,
     this.color,

--- a/lib/components/widgets/harpy_background.dart
+++ b/lib/components/widgets/harpy_background.dart
@@ -19,8 +19,8 @@ class HarpyBackground extends ConsumerWidget {
       duration: kShortAnimationDuration,
       decoration: BoxDecoration(
         gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
+          begin: AlignmentDirectional.topCenter,
+          end: AlignmentDirectional.bottomCenter,
           colors: colors.length == 1
               ? List.filled(2, colors.single)
               : colors.toList(),

--- a/lib/components/widgets/harpy_button.dart
+++ b/lib/components/widgets/harpy_button.dart
@@ -10,7 +10,7 @@ abstract class HarpyButton extends ConsumerWidget {
     required VoidCallback? onTap,
     Widget? icon,
     Widget? label,
-    EdgeInsets? padding,
+    EdgeInsetsGeometry? padding,
   }) = _HarpyTextButton;
 
   /// Equivalent to an [ElevatedButton].
@@ -18,7 +18,7 @@ abstract class HarpyButton extends ConsumerWidget {
     required VoidCallback? onTap,
     Widget? icon,
     Widget? label,
-    EdgeInsets? padding,
+    EdgeInsetsGeometry? padding,
   }) = _HarpyElevatedButton;
 
   /// A flat transparent icon button.
@@ -27,7 +27,7 @@ abstract class HarpyButton extends ConsumerWidget {
     Widget? icon,
     Widget? label,
     VoidCallback? onLongPress,
-    EdgeInsets? padding,
+    EdgeInsetsGeometry? padding,
   }) = _HarpyIconButton;
 
   /// A flat button that matches a [Card].
@@ -36,7 +36,7 @@ abstract class HarpyButton extends ConsumerWidget {
     Widget? icon,
     Widget? label,
     VoidCallback? onLongPress,
-    EdgeInsets? padding,
+    EdgeInsetsGeometry? padding,
     Color? foregroundColor,
     Color? backgroundColor,
   }) = _HarpyCardButton;
@@ -53,7 +53,7 @@ class _HarpyTextButton extends HarpyButton {
   final Widget? icon;
   final Widget? label;
   final VoidCallback? onTap;
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -87,7 +87,7 @@ class _HarpyElevatedButton extends HarpyButton {
   final Widget? icon;
   final Widget? label;
   final VoidCallback? onTap;
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -125,7 +125,7 @@ class _HarpyCardButton extends HarpyButton {
   final Widget? label;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
   final Color? foregroundColor;
   final Color? backgroundColor;
 
@@ -180,7 +180,7 @@ class _HarpyIconButton extends HarpyButton {
 
   final Widget? icon;
   final Widget? label;
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
 

--- a/lib/components/widgets/harpy_dialog.dart
+++ b/lib/components/widgets/harpy_dialog.dart
@@ -23,9 +23,9 @@ class HarpyDialog extends ConsumerWidget {
 
   final Clip clipBehavior;
 
-  final EdgeInsets? titlePadding;
-  final EdgeInsets? contentPadding;
-  final EdgeInsets? actionsPadding;
+  final EdgeInsetsGeometry? titlePadding;
+  final EdgeInsetsGeometry? contentPadding;
+  final EdgeInsetsGeometry? actionsPadding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -53,7 +53,7 @@ class HarpyDialog extends ConsumerWidget {
         child: AnimatedSize(
           duration: kShortAnimationDuration,
           curve: Curves.easeInOut,
-          alignment: Alignment.topCenter,
+          alignment: AlignmentDirectional.topCenter,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -91,7 +91,7 @@ class HarpyDialogActionBar extends ConsumerWidget {
   });
 
   final List<Widget> actions;
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/components/widgets/harpy_list_tile.dart
+++ b/lib/components/widgets/harpy_list_tile.dart
@@ -30,9 +30,9 @@ class HarpyListTile extends ConsumerWidget {
   final VoidCallback? onTap;
   final bool enabled;
 
-  final EdgeInsets? contentPadding;
-  final EdgeInsets? leadingPadding;
-  final EdgeInsets? trailingPadding;
+  final EdgeInsetsGeometry? contentPadding;
+  final EdgeInsetsGeometry? leadingPadding;
+  final EdgeInsetsGeometry? trailingPadding;
   final CrossAxisAlignment verticalAlignment;
   final bool multilineTitle;
   final bool multilineSubtitle;

--- a/lib/components/widgets/harpy_pro_card.dart
+++ b/lib/components/widgets/harpy_pro_card.dart
@@ -50,8 +50,8 @@ class HarpyProCard extends ConsumerWidget {
         child: DecoratedBox(
           decoration: const BoxDecoration(
             gradient: LinearGradient(
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
+              begin: AlignmentDirectional.topStart,
+              end: AlignmentDirectional.bottomEnd,
               colors: [
                 Color(0xff8B00FD),
                 Color(0xffBC0492),

--- a/lib/components/widgets/harpy_radio_tile.dart
+++ b/lib/components/widgets/harpy_radio_tile.dart
@@ -20,9 +20,9 @@ class HarpyRadioTile<T> extends ConsumerWidget {
 
   final Widget? title;
   final Widget? subtitle;
-  final EdgeInsets? contentPadding;
-  final EdgeInsets? leadingPadding;
-  final EdgeInsets? trailingPadding;
+  final EdgeInsetsGeometry? contentPadding;
+  final EdgeInsetsGeometry? leadingPadding;
+  final EdgeInsetsGeometry? trailingPadding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/components/widgets/info_message.dart
+++ b/lib/components/widgets/info_message.dart
@@ -25,7 +25,7 @@ class InfoMessage extends ConsumerWidget {
       duration: kShortAnimationDuration,
       child: Container(
         padding: display.edgeInsets,
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/components/widgets/loading_error.dart
+++ b/lib/components/widgets/loading_error.dart
@@ -25,7 +25,7 @@ class LoadingError extends ConsumerWidget {
       duration: kShortAnimationDuration,
       child: Container(
         padding: display.edgeInsets,
-        alignment: Alignment.center,
+        alignment: AlignmentDirectional.center,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/components/widgets/loading_shimmer/placeholder_box.dart
+++ b/lib/components/widgets/loading_shimmer/placeholder_box.dart
@@ -9,7 +9,7 @@ class PlaceholderBox extends ConsumerWidget {
     this.widthFactor,
     this.heightFactor,
     this.shape = BoxShape.rectangle,
-    this.alignment = Alignment.center,
+    this.alignment = AlignmentDirectional.center,
   });
 
   final double? width;
@@ -17,7 +17,7 @@ class PlaceholderBox extends ConsumerWidget {
   final double? widthFactor;
   final double? heightFactor;
   final BoxShape shape;
-  final Alignment alignment;
+  final AlignmentGeometry alignment;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/components/widgets/loading_shimmer/trends_list_loading_shimmer.dart
+++ b/lib/components/widgets/loading_shimmer/trends_list_loading_shimmer.dart
@@ -22,7 +22,9 @@ class TrendsListLoadingSliver extends ConsumerWidget {
           children: List.filled(
             25,
             Padding(
-              padding: EdgeInsets.only(bottom: display.paddingValue * 2),
+              padding: EdgeInsetsDirectional.only(
+                bottom: display.paddingValue * 2,
+              ),
               child: const TrendsPlaceholder(),
             ),
           ),

--- a/lib/components/widgets/loading_shimmer/tweet_list_info_message_loading_shimmer.dart
+++ b/lib/components/widgets/loading_shimmer/tweet_list_info_message_loading_shimmer.dart
@@ -44,7 +44,7 @@ class InfoRowPlaceholder extends ConsumerWidget {
           child: PlaceholderBox(
             widthFactor: .3,
             height: 15,
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
           ),
         ),
       ],

--- a/lib/components/widgets/loading_shimmer/tweet_list_loading_shimmer.dart
+++ b/lib/components/widgets/loading_shimmer/tweet_list_loading_shimmer.dart
@@ -25,7 +25,9 @@ class TweetListLoadingSliver extends ConsumerWidget {
                 ...List.filled(
                   15,
                   Padding(
-                    padding: EdgeInsets.only(bottom: display.paddingValue * 2),
+                    padding: EdgeInsetsDirectional.only(
+                      bottom: display.paddingValue * 2,
+                    ),
                     child: const TweetPlaceholder(),
                   ),
                 ),

--- a/lib/components/widgets/loading_shimmer/user_list_loading_shimmer.dart
+++ b/lib/components/widgets/loading_shimmer/user_list_loading_shimmer.dart
@@ -19,7 +19,9 @@ class UserListLoadingSliver extends ConsumerWidget {
           children: List.filled(
             25,
             Padding(
-              padding: EdgeInsets.only(bottom: display.paddingValue * 2),
+              padding: EdgeInsetsDirectional.only(
+                bottom: display.paddingValue * 2,
+              ),
               child: const UserPlaceholder(),
             ),
           ),

--- a/lib/components/widgets/scroll_to_top.dart
+++ b/lib/components/widgets/scroll_to_top.dart
@@ -94,7 +94,7 @@ class _ScrollToTopState extends ConsumerState<ScrollToTop> {
       children: [
         widget.child,
         Align(
-          alignment: Alignment.bottomCenter,
+          alignment: AlignmentDirectional.bottomCenter,
           child: AnimatedOpacity(
             opacity: _show ? 1 : 0,
             curve: Curves.easeInOut,

--- a/lib/components/widgets/slivers/harpy_sliver_app_bar.dart
+++ b/lib/components/widgets/slivers/harpy_sliver_app_bar.dart
@@ -128,7 +128,7 @@ class _SliverHeaderDelegate extends SliverPersistentHeaderDelegate {
 
     if (child != null) {
       return Padding(
-        padding: EdgeInsets.only(left: paddingValue / 2),
+        padding: EdgeInsetsDirectional.only(start: paddingValue / 2),
         child: child,
       );
     } else {
@@ -157,7 +157,7 @@ class _SliverHeaderDelegate extends SliverPersistentHeaderDelegate {
 
     if (child != null) {
       return Padding(
-        padding: EdgeInsets.only(right: paddingValue / 2),
+        padding: EdgeInsetsDirectional.only(end: paddingValue / 2),
         child: child,
       );
     } else {
@@ -187,8 +187,8 @@ class _SliverHeaderDelegate extends SliverPersistentHeaderDelegate {
     return BoxDecoration(
       gradient: LinearGradient(
         colors: [begin.withOpacity(.8), end.withOpacity(.8)],
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
+        begin: AlignmentDirectional.topCenter,
+        end: AlignmentDirectional.bottomCenter,
       ),
     );
   }
@@ -208,7 +208,7 @@ class _SliverHeaderDelegate extends SliverPersistentHeaderDelegate {
       child: Material(
         type: MaterialType.transparency,
         child: Padding(
-          padding: EdgeInsets.only(top: topPadding),
+          padding: EdgeInsetsDirectional.only(top: topPadding),
           child: NavigationToolbar(
             leading: _leading(context),
             middle: title != null

--- a/lib/components/widgets/slivers/sliver_loading_indicator.dart
+++ b/lib/components/widgets/slivers/sliver_loading_indicator.dart
@@ -17,7 +17,7 @@ class SliverLoadingIndicator extends ConsumerWidget {
         duration: kShortAnimationDuration,
         child: Container(
           padding: display.edgeInsets,
-          alignment: Alignment.center,
+          alignment: AlignmentDirectional.center,
           child: const CircularProgressIndicator(),
         ),
       ),

--- a/lib/components/widgets/system_gesture_placeholder.dart
+++ b/lib/components/widgets/system_gesture_placeholder.dart
@@ -20,21 +20,21 @@ class SystemGesturePlaceholder extends StatelessWidget {
       children: [
         child,
         Align(
-          alignment: Alignment.centerLeft,
+          alignment: AlignmentDirectional.centerEnd,
           child: SizedBox(
             width: mediaQuery.size.width * .066,
             child: GestureDetector(onHorizontalDragStart: (_) {}),
           ),
         ),
         Align(
-          alignment: Alignment.centerRight,
+          alignment: AlignmentDirectional.centerEnd,
           child: SizedBox(
             width: mediaQuery.size.width * .066,
             child: GestureDetector(onHorizontalDragStart: (_) {}),
           ),
         ),
         Align(
-          alignment: Alignment.bottomCenter,
+          alignment: AlignmentDirectional.bottomCenter,
           child: SizedBox(
             height: mediaQuery.size.height * .044,
             child: GestureDetector(

--- a/lib/components/widgets/tab_bar/harpy_tab.dart
+++ b/lib/components/widgets/tab_bar/harpy_tab.dart
@@ -100,7 +100,7 @@ class _HarpyTabState extends ConsumerState<HarpyTab>
       opacity: _textOpacityAnimation.value,
       child: Align(
         widthFactor: 1 - _animationController.value,
-        alignment: Alignment.centerRight,
+        alignment: AlignmentDirectional.centerEnd,
         child: Row(
           children: [
             smallHorizontalSpacer,

--- a/lib/components/widgets/tab_bar/harpy_tab_bar.dart
+++ b/lib/components/widgets/tab_bar/harpy_tab_bar.dart
@@ -21,7 +21,7 @@ class HarpyTabBar extends ConsumerStatefulWidget {
   final List<Widget>? endWidgets;
 
   /// Padding around the [tabs] inside the scroll view.
-  final EdgeInsets padding;
+  final EdgeInsetsGeometry padding;
 
   final TabController? controller;
 

--- a/lib/components/widgets/translated_text.dart
+++ b/lib/components/widgets/translated_text.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:harpy/api/api.dart';
 import 'package:harpy/components/components.dart';
+import 'package:harpy/core/core.dart';
 
-class TranslatedText extends StatelessWidget {
+class TranslatedText extends ConsumerWidget {
   const TranslatedText(
     this.text, {
     this.language,
+    this.textDirection,
     this.entities,
     this.urlToIgnore,
     this.fontSizeDelta = 0,
@@ -13,13 +16,21 @@ class TranslatedText extends StatelessWidget {
 
   final String text;
   final String? language;
+  final TextDirection? textDirection;
   final EntitiesData? entities;
   final String? urlToIgnore;
   final double fontSizeDelta;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final locale = Localizations.localeOf(context);
+    final translateLanguage =
+        ref.watch(languagePreferencesProvider).activeTranslateLanguage(locale);
+
+    final textDirection = rtlLanguageCodes.contains(translateLanguage)
+        ? TextDirection.rtl
+        : TextDirection.ltr;
 
     final bodyText1 = theme.textTheme.bodyText1!.apply(
       fontSizeDelta: fontSizeDelta,
@@ -29,31 +40,34 @@ class TranslatedText extends StatelessWidget {
       fontSizeDelta: fontSizeDelta,
     );
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        // 'translated from' original language text
-        Text.rich(
-          TextSpan(
-            children: [
-              const TextSpan(text: 'translated from'),
-              TextSpan(
-                text: ' ${language ?? 'unknown'}',
-                style: const TextStyle(fontWeight: FontWeight.bold),
-              ),
-            ],
+    return Directionality(
+      textDirection: textDirection,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // 'translated from' original language text
+          Text.rich(
+            TextSpan(
+              children: [
+                const TextSpan(text: 'translated from'),
+                TextSpan(
+                  text: ' ${language ?? 'unknown'}',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            style: bodyText1,
           ),
-          style: bodyText1,
-        ),
 
-        // translated text
-        TwitterText(
-          text,
-          entities: entities,
-          urlToIgnore: urlToIgnore,
-          style: bodyText2,
-        ),
-      ],
+          // translated text
+          TwitterText(
+            text,
+            entities: entities,
+            urlToIgnore: urlToIgnore,
+            style: bodyText2,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/components/widgets/video_player/video_player_double_tap_actions.dart
+++ b/lib/components/widgets/video_player/video_player_double_tap_actions.dart
@@ -29,7 +29,7 @@ class _VideoPlayerDoubleTapActionsState
       children: [
         Expanded(
           child: Stack(
-            alignment: Alignment.center,
+            alignment: AlignmentDirectional.center,
             children: [
               GestureDetector(
                 onDoubleTap: () {
@@ -52,7 +52,7 @@ class _VideoPlayerDoubleTapActionsState
         const Spacer(),
         Expanded(
           child: Stack(
-            alignment: Alignment.center,
+            alignment: AlignmentDirectional.center,
             children: [
               GestureDetector(
                 onDoubleTap: () {

--- a/lib/components/widgets/video_player/video_player_progress_indicator.dart
+++ b/lib/components/widgets/video_player/video_player_progress_indicator.dart
@@ -16,12 +16,13 @@ class VideoPlayerProgressIndicator extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Transform(
-      alignment: Alignment.bottomCenter,
+      alignment: AlignmentDirectional.bottomCenter,
       transform: Matrix4.diagonal3Values(1, compact ? .33 : .66, 1),
       transformHitTests: false,
       child: VideoProgressIndicator(
         notifier.controller,
         allowScrubbing: true,
+        // ignore: non_directional
         padding: EdgeInsets.only(top: compact ? 12 : 24),
         colors: VideoProgressColors(
           playedColor: theme.colorScheme.primary.withOpacity(.7),

--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -5,6 +5,7 @@ export 'misc/environment.dart';
 export 'misc/error_handler.dart';
 export 'misc/list_utils.dart';
 export 'misc/request_lock_mixin.dart';
+export 'misc/rtl_language_codes.dart';
 export 'misc/string_utils.dart';
 export 'misc/twitter_error_handler.dart';
 export 'misc/video_autopause_observer.dart';

--- a/lib/core/misc/rtl_language_codes.dart
+++ b/lib/core/misc/rtl_language_codes.dart
@@ -1,0 +1,8 @@
+const rtlLanguageCodes = [
+  'ar', // Arabic
+  'fa', // Farsi / Persian
+  'he', // Hebrew
+  'iw', // Hebrew (old code, used by Twitter)
+  'ps', // Pashto
+  'ur', // Urdu
+];

--- a/lib/rby/animations/explicit/bubble_animation.dart
+++ b/lib/rby/animations/explicit/bubble_animation.dart
@@ -126,9 +126,9 @@ class _BubbleAnimationState extends State<BubbleAnimation> {
         clipBehavior: Clip.none,
         children: [
           // bubbles
-          Positioned(
+          PositionedDirectional(
             top: (size - bubbleSize) / 2.0,
-            left: (size - bubbleSize) / 2.0,
+            start: (size - bubbleSize) / 2.0,
             child: CustomPaint(
               size: Size(bubbleSize, bubbleSize),
               painter: _BubblesPainter(
@@ -139,9 +139,9 @@ class _BubbleAnimationState extends State<BubbleAnimation> {
           ),
 
           // circle
-          Positioned(
+          PositionedDirectional(
             top: (size - circleSize) / 2,
-            left: (size - circleSize) / 2,
+            start: (size - circleSize) / 2,
             child: CustomPaint(
               size: Size(circleSize, circleSize),
               painter: _CirclePainter(

--- a/lib/rby/widgets/badge.dart
+++ b/lib/rby/widgets/badge.dart
@@ -4,7 +4,7 @@ class Badge extends StatelessWidget {
   const Badge({
     required this.child,
     this.offset = Offset.zero,
-    this.alignment = Alignment.topRight,
+    this.alignment = AlignmentDirectional.topStart,
     this.show = true,
   }) : badge = const _Bubble();
 
@@ -12,7 +12,7 @@ class Badge extends StatelessWidget {
     required this.child,
     required this.badge,
     this.offset = Offset.zero,
-    this.alignment = Alignment.topRight,
+    this.alignment = AlignmentDirectional.topEnd,
     this.show = true,
   });
 


### PR DESCRIPTION
Closes #527

- Fixed & improved layout for right-to-left languages throughout the app
  - For Arabic, Persian, Hebrew, Pashto and Urdu
  - Tweet text is now laid out based on the Tweet's language (this does not include the description of a user)
- Fixed translate language setting not persisting across 
