### PR TITLE
Change auth error dialog from "cancel" to "logout"

### DIFF
--- a/lib/components/authentication/widgets/retry_authentication_dialog.dart
+++ b/lib/components/authentication/widgets/retry_authentication_dialog.dart
@@ -14,7 +14,7 @@ class RetryAuthenticationDialog extends StatelessWidget {
       ),
       actions: [
         HarpyButton.text(
-          label: const Text('cancel'),
+          label: const Text('logout'),
           onTap: Navigator.of(context).pop,
         ),
         HarpyButton.elevated(


### PR DESCRIPTION
Fixes #789 

Signed-off-by: Mark Bestavros <markbest@bu.edu>