### PR TITLE
FIXES #779 | Open unhandled twitter deeplinks in an external webview

### DIFF
--- a/lib/core/router/handle_redirect.dart
+++ b/lib/core/router/handle_redirect.dart
@@ -32,9 +32,6 @@ adb shell am start -a android.intent.action.VIEW \
  -d "https://twitter.com/harpy_app/followers"
 */
 
-/// Twitter prefix URL constant
-const String twitterPrefix = 'https://twitter.com/';
-
 /// Paths that an unauthenticated user can access.
 ///
 /// If the requested path is a sublocation of an unprotected path, it can still

--- a/lib/core/router/handle_redirect.dart
+++ b/lib/core/router/handle_redirect.dart
@@ -74,7 +74,7 @@ String? handleRedirect(Ref ref, GoRouterState state) {
 
     // if the location doesn't exist, launch it and navigate to home instead
     final launcher = ref.watch(launcherProvider);
-    launcher(twitterPrefix + state.location);
+    launcher('https://twitter.com${state.location}');
     return '/';
   }
 

--- a/lib/core/router/handle_redirect.dart
+++ b/lib/core/router/handle_redirect.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:harpy/components/components.dart';
@@ -33,6 +31,9 @@ adb shell am start -a android.intent.action.VIEW \
  -c android.intent.category.BROWSABLE \
  -d "https://twitter.com/harpy_app/followers"
 */
+
+/// Twitter prefix URL constant
+const String twitterPrefix = 'https://twitter.com/';
 
 /// Paths that an unauthenticated user can access.
 ///
@@ -73,9 +74,7 @@ String? handleRedirect(Ref ref, GoRouterState state) {
 
     // if the location doesn't exist, launch it and navigate to home instead
     final launcher = ref.watch(launcherProvider);
-    launcher(state.location).onError((error, stackTrace) {
-      log('failed to launch url: $error');
-    });
+    launcher(twitterPrefix + state.location);
     return '/';
   }
 

--- a/lib/core/router/handle_redirect.dart
+++ b/lib/core/router/handle_redirect.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
+import 'package:harpy/rby/rby.dart';
 
 /*
 example deeplinks

--- a/lib/core/router/handle_redirect.dart
+++ b/lib/core/router/handle_redirect.dart
@@ -2,7 +2,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
-import 'package:harpy/rby/rby.dart';
 
 /*
 example deeplinks

--- a/lib/core/router/handle_redirect.dart
+++ b/lib/core/router/handle_redirect.dart
@@ -1,7 +1,10 @@
+import 'dart:developer';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
+import 'package:harpy/rby/core/url_launcher.dart';
 
 /*
 example deeplinks
@@ -68,7 +71,11 @@ String? handleRedirect(Ref ref, GoRouterState state) {
     final mappedLocation = _mapTwitterPath(state);
     if (mappedLocation != null) return mappedLocation;
 
-    // if the location doesn't exist navigate to home instead
+    // if the location doesn't exist, launch it and navigate to home instead
+    final launcher = ref.watch(launcherProvider);
+    launcher(state.location).onError((error, stackTrace) {
+      log('failed to launch url: $error');
+    });
     return '/';
   }
 

--- a/lib/core/router/handle_redirect.dart
+++ b/lib/core/router/handle_redirect.dart
@@ -2,7 +2,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:harpy/components/components.dart';
 import 'package:harpy/core/core.dart';
-import 'package:harpy/rby/core/url_launcher.dart';
 
 /*
 example deeplinks


### PR DESCRIPTION
Created url_launcher based redirect for unparsable twitter URLs.

This is the fix for Issue [#779](https://github.com/robertodoering/harpy/issues/779).