### PR TITLE
feat: add link preview to `TweetCardLinkPreview`

### DIFF
--- a/lib/components/tweet/widgets/card_content/tweet_card_link_preview.dart
+++ b/lib/components/tweet/widgets/card_content/tweet_card_link_preview.dart
@@ -19,9 +19,18 @@ class TweetCardLinkPreview extends ConsumerWidget {
     final theme = Theme.of(context);
     final harpyTheme = ref.watch(harpyThemeProvider);
     final launcher = ref.watch(launcherProvider);
+    final urlString = tweet.previewUrl.toString();
 
     return GestureDetector(
-      onTap: () => launcher('${tweet.previewUrl}'),
+      onTap: () => launcher(urlString),
+      onLongPress: () => defaultOnUrlLongPress(
+        ref,
+        UrlData(
+          expandedUrl: urlString,
+          displayUrl: urlString,
+          url: urlString,
+        ),
+      ),
       child: AnyLinkPreview.builder(
         link: '${tweet.previewUrl}',
         placeholderWidget: const _LinkPreviewPlaceholder(),


### PR DESCRIPTION
### Goal
- add BottomSheet showing link preview when long pressing on `TweetCardLinkPreview`

closes #781 