### PR TITLE
feat: add option to start video playback muted

### DIFF
--- a/lib/components/settings/media/media_settings_page.dart
+++ b/lib/components/settings/media/media_settings_page.dart
@@ -144,9 +144,9 @@ class _MediaSettingsList extends ConsumerWidget {
           child: HarpySwitchTile(
             leading: const Icon(CupertinoIcons.volume_off),
             title: const Text('start video playback muted'),
-            value: media.openLinksExternally, // todo change
+            value: media.startVideoPlaybackMuted,
             borderRadius: harpyTheme.borderRadius,
-            onChanged: mediaNotifier.setOpenLinksExternally, // todo change
+            onChanged: mediaNotifier.setStartVideoPlaybackMuted,
           ),
         ),
         verticalSpacer,

--- a/lib/components/settings/media/media_settings_page.dart
+++ b/lib/components/settings/media/media_settings_page.dart
@@ -140,6 +140,16 @@ class _MediaSettingsList extends ConsumerWidget {
           ],
         ),
         verticalSpacer,
+        Card(
+          child: HarpySwitchTile(
+            leading: const Icon(CupertinoIcons.volume_off),
+            title: const Text('start video playback muted'),
+            value: media.openLinksExternally, // todo change
+            borderRadius: harpyTheme.borderRadius,
+            onChanged: mediaNotifier.setOpenLinksExternally, // todo change
+          ),
+        ),
+        verticalSpacer,
         const _MediaDownloadSettings(),
       ]),
     );

--- a/lib/components/settings/media/preferences/media_preferences.dart
+++ b/lib/components/settings/media/preferences/media_preferences.dart
@@ -24,6 +24,10 @@ class MediaPreferencesNotifier extends StateNotifier<MediaPreferences> {
             cropImage: preferences.getBool('cropImage', false),
             autoplayGifs: preferences.getInt('autoplayMedia', 1),
             autoplayVideos: preferences.getInt('autoplayVideos', 2),
+            startVideoPlaybackMuted: preferences.getBool(
+              'startVideoPlaybackMuted',
+              false,
+            ),
             hidePossiblySensitive: preferences.getBool(
               'hidePossiblySensitive',
               false,
@@ -44,6 +48,7 @@ class MediaPreferencesNotifier extends StateNotifier<MediaPreferences> {
     setCropImage(false);
     setAutoplayGifs(1);
     setAutoplayVideos(2);
+    setStartVideoPlaybackMuted(false);
     setHidePossiblySensitive(false);
     setOpenLinksExternally(false);
     setShowDownloadDialog(true);
@@ -69,6 +74,11 @@ class MediaPreferencesNotifier extends StateNotifier<MediaPreferences> {
   void setAutoplayVideos(int value) {
     state = state.copyWith(autoplayVideos: value);
     _preferences.setInt('autoplayVideos', value);
+  }
+
+  void setStartVideoPlaybackMuted(bool value) {
+    state = state.copyWith(startVideoPlaybackMuted: value);
+    _preferences.setBool('startVideoPlaybackMuted', value);
   }
 
   void setHidePossiblySensitive(bool value) {
@@ -122,6 +132,9 @@ class MediaPreferences with _$MediaPreferences {
     /// 1: only autoplay when using wifi
     /// 2: never autoplay
     required int autoplayVideos,
+
+    /// Whether video playback should start with volume 0 by default.
+    required bool startVideoPlaybackMuted,
 
     /// Whether possibly sensitive (NSFW) media should be hidden by default.
     required bool hidePossiblySensitive,

--- a/lib/components/tweet/widgets/card_content/tweet_card_link_preview.dart
+++ b/lib/components/tweet/widgets/card_content/tweet_card_link_preview.dart
@@ -19,9 +19,18 @@ class TweetCardLinkPreview extends ConsumerWidget {
     final theme = Theme.of(context);
     final harpyTheme = ref.watch(harpyThemeProvider);
     final launcher = ref.watch(launcherProvider);
+    final urlString = tweet.previewUrl.toString();
 
     return GestureDetector(
-      onTap: () => launcher('${tweet.previewUrl}'),
+      onTap: () => launcher(urlString),
+      onLongPress: () => defaultOnUrlLongPress(
+        ref,
+        UrlData(
+          expandedUrl: urlString,
+          displayUrl: urlString,
+          url: urlString,
+        ),
+      ),
       child: AnyLinkPreview.builder(
         link: '${tweet.previewUrl}',
         placeholderWidget: const _LinkPreviewPlaceholder(),

--- a/lib/components/widgets/video_player/video_player_provider.dart
+++ b/lib/components/widgets/video_player/video_player_provider.dart
@@ -13,12 +13,11 @@ final videoPlayerProvider = StateNotifierProvider.autoDispose
     .family<VideoPlayerNotifier, VideoPlayerState, VideoPlayerArguments>(
   (ref, arguments) {
     final handler = ref.watch(videoPlayerHandlerProvider);
-    final mediaPreferences = ref.watch(mediaPreferencesProvider);
 
     final notifier = VideoPlayerNotifier(
       urls: arguments.urls,
       loop: arguments.loop,
-      startVideoPlaybackMuted: mediaPreferences.startVideoPlaybackMuted,
+      ref: ref,
       onInitialized: arguments.isVideo
           ? () => handler.act((notifier) => notifier.pause())
           : null,
@@ -37,13 +36,13 @@ class VideoPlayerNotifier extends StateNotifier<VideoPlayerState> {
   VideoPlayerNotifier({
     required BuiltMap<String, String> urls,
     required bool loop,
-    required bool startVideoPlaybackMuted,
+    required Ref ref,
     VoidCallback? onInitialized,
   })  : assert(urls.isNotEmpty),
         _onInitialized = onInitialized,
         _urls = urls,
         _loop = loop,
-        _startVideoPlaybackMuted = startVideoPlaybackMuted,
+        _ref = ref,
         super(const VideoPlayerState.uninitialized()) {
     _quality = urls.keys.first;
 
@@ -56,7 +55,7 @@ class VideoPlayerNotifier extends StateNotifier<VideoPlayerState> {
   final BuiltMap<String, String> _urls;
   final bool _loop;
   final VoidCallback? _onInitialized;
-  final bool _startVideoPlaybackMuted;
+  final Ref _ref;
 
   late String _quality;
 
@@ -91,7 +90,10 @@ class VideoPlayerNotifier extends StateNotifier<VideoPlayerState> {
   Future<void> initialize({double volume = 1}) async {
     state = const VideoPlayerState.loading();
 
-    if (_startVideoPlaybackMuted) {
+    final startVideoPlaybackMuted =
+        _ref.read(mediaPreferencesProvider).startVideoPlaybackMuted;
+
+    if (startVideoPlaybackMuted) {
       volume = 0;
     }
 

--- a/lib/components/widgets/video_player/video_player_provider.dart
+++ b/lib/components/widgets/video_player/video_player_provider.dart
@@ -13,10 +13,12 @@ final videoPlayerProvider = StateNotifierProvider.autoDispose
     .family<VideoPlayerNotifier, VideoPlayerState, VideoPlayerArguments>(
   (ref, arguments) {
     final handler = ref.watch(videoPlayerHandlerProvider);
+    final mediaPreferences = ref.watch(mediaPreferencesProvider);
 
     final notifier = VideoPlayerNotifier(
       urls: arguments.urls,
       loop: arguments.loop,
+      startVideoPlaybackMuted: mediaPreferences.startVideoPlaybackMuted,
       onInitialized: arguments.isVideo
           ? () => handler.act((notifier) => notifier.pause())
           : null,
@@ -35,11 +37,13 @@ class VideoPlayerNotifier extends StateNotifier<VideoPlayerState> {
   VideoPlayerNotifier({
     required BuiltMap<String, String> urls,
     required bool loop,
+    required bool startVideoPlaybackMuted,
     VoidCallback? onInitialized,
   })  : assert(urls.isNotEmpty),
         _onInitialized = onInitialized,
         _urls = urls,
         _loop = loop,
+        _startVideoPlaybackMuted = startVideoPlaybackMuted,
         super(const VideoPlayerState.uninitialized()) {
     _quality = urls.keys.first;
 
@@ -52,6 +56,7 @@ class VideoPlayerNotifier extends StateNotifier<VideoPlayerState> {
   final BuiltMap<String, String> _urls;
   final bool _loop;
   final VoidCallback? _onInitialized;
+  final bool _startVideoPlaybackMuted;
 
   late String _quality;
 
@@ -85,6 +90,10 @@ class VideoPlayerNotifier extends StateNotifier<VideoPlayerState> {
   /// Starts loading the video and then plays it.
   Future<void> initialize({double volume = 1}) async {
     state = const VideoPlayerState.loading();
+
+    if (_startVideoPlaybackMuted) {
+      volume = 0;
+    }
 
     await _controller
         .initialize()


### PR DESCRIPTION
## Goals
- Add settings option to mute videos by default
- Reflect selection on video player

## Notes
- It was the first time working with Riverpod for me, I hope I understood the concepts correctly. Feel free to suggest improvements, I am open to feedback!


closes #778