### PR TITLE
added scroll direction change threshold to address excessive sensitivity of timeline widgets

### DIFF
--- a/lib/components/widgets/scroll_direction_listener.dart
+++ b/lib/components/widgets/scroll_direction_listener.dart
@@ -7,6 +7,10 @@ import 'package:harpy/core/core.dart';
 /// has a `maxScrollExtent` of this threshold.
 const _maxScrollExtentThreshold = 200;
 
+/// Scroll direction changes will only be applied if the affected scroll view
+/// has scrolled through this amount of pixels after changing scroll direction.
+const _scrollDirectionThreshold = 15;
+
 /// Listens to [UserScrollNotification] that bubble up the tree to expose
 /// changes to the [ScrollDirection] to its children.
 ///
@@ -37,7 +41,18 @@ class _ScrollDirectionListenerState
     extends ConsumerState<ScrollDirectionListener> with RouteAware {
   RouteObserver? _observer;
 
+  /// Last known scroll position.
+  double _scrollValue = 0;
+
+  /// Position at which scroll direction changed.
+  double _scrollStart = 0;
+
+  /// Last scroll direction known to the listeners.
   ScrollDirection _direction = ScrollDirection.idle;
+
+  /// Direction in which the user is currently scrolling.
+  /// May be different from [_direction] due to [_scrollDirectionThreshold].
+  ScrollDirection _directionInterim = ScrollDirection.idle;
 
   // Assume scrolling up when a new route gets popped / pushed onto the screen.
   // This is a workaround for scroll direction sensitive animations to prevent
@@ -64,16 +79,31 @@ class _ScrollDirectionListenerState
     super.dispose();
   }
 
-  bool _onNotification(UserScrollNotification notification) {
+  bool _onNotification(ScrollNotification notification) {
     if (widget.depth != null && notification.depth != widget.depth) {
       return false;
     }
 
-    if (mounted &&
-        notification.direction != ScrollDirection.idle &&
-        notification.metrics.maxScrollExtent > _maxScrollExtentThreshold &&
-        _direction != notification.direction) {
-      setState(() => _direction = notification.direction);
+    final metrics = notification.metrics;
+
+    if (mounted && metrics.maxScrollExtent > _maxScrollExtentThreshold) {
+      final scrollValue = metrics.pixels;
+      final scrollDirection = scrollValue - _scrollValue < 0
+          ? ScrollDirection.forward
+          : ScrollDirection.reverse;
+
+      if (_directionInterim != scrollDirection) {
+        _directionInterim = scrollDirection;
+        _scrollStart = scrollValue;
+      }
+
+      if (_direction != scrollDirection) {
+        if ((scrollValue - _scrollStart).abs() > _scrollDirectionThreshold) {
+          _set(scrollDirection);
+        }
+      }
+
+      _scrollValue = scrollValue;
     }
 
     return false;
@@ -85,7 +115,7 @@ class _ScrollDirectionListenerState
 
   @override
   Widget build(BuildContext context) {
-    return NotificationListener<UserScrollNotification>(
+    return NotificationListener<ScrollNotification>(
       onNotification: _onNotification,
       child: UserScrollDirection(
         direction: _direction,

--- a/lib/components/widgets/scroll_direction_listener.dart
+++ b/lib/components/widgets/scroll_direction_listener.dart
@@ -88,7 +88,7 @@ class _ScrollDirectionListenerState
 
     if (mounted && metrics.maxScrollExtent > _maxScrollExtentThreshold) {
       final scrollValue = metrics.pixels;
-      final scrollDirection = scrollValue - _scrollValue < 0
+      final scrollDirection = scrollValue == 0 || scrollValue - _scrollValue < 0
           ? ScrollDirection.forward
           : ScrollDirection.reverse;
 


### PR DESCRIPTION
Hello!

Thank you for the amazing app, I absolutely love it! Please consider reviewing and merging this pull request! 🙌 

## what is addressed in the pr

I'm having one inconvenience on my Pixel 6. Auto-hiding elements in the timeline (scroll-to-top-button and top-panel, highlighted on the screenshot) sometimes appear when I'm only scrolling to bottom. These elements as I understand are expected to appear only when scrolling to top. I assume this is not just me and my device however I have not found that reported by anyone so I'm opening this pull request without a corresponding plea.

<details><summary>Screenshot</summary>

![IMAGE 2022-11-13 23:37:41](https://user-images.githubusercontent.com/20713003/201576354-cf853a0a-7569-4127-8baf-7963b0b7b207.jpg)

</details>

## how it's addressed in the pr

I've added a threshold to the scrolling direction notifier and confirmed that proposed changes address the issue.

## related things to point out

I have not tested the changes on other phones or emulators nor investigated the repercussions in the code base.